### PR TITLE
fix:config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)を削除

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,6 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")


### PR DESCRIPTION
## 概要
- デプロイ時に以下のエラーがでたため、`config/environments/production.rb`を修正
```
NoMethodError: undefined method logger' for ActiveSupport::TaggedLogging:Module (NoMethodError)
```

## 変更内容
```
config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
```
の記載を削除