### PR TITLE
fix:schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 0) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## 概要
`docker compose build`をして`docker compose up`をした際に、webコンテナが立ち上がらない事案が発生
⇒`schema.rb`を8.0から7.2にバージョン変更

## 変更内容
- schema.rb (`/Users/kogoro/programing_quiz/db/schema.rb`)にてバージョン変更
```
ActiveRecord::Schema[8.0].define(version: 0) do
⇒ActiveRecord::Schema[7.2].define(version: 0) do
```

## 動作確認方法

1. ターミナル上で`docker compose build`
2. ターミナル上で`docker compose up`

`localhost3000`が開けることを確認



