### PR TITLE
feat:generatorで不要なテストファイルが作成

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,12 @@ module Myapp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.generators do |g|
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## 概要
- `rails generate controller` をした際に不要なファイルが作成されないようにしました

## 変更内容
- **修正**: `config/application.rb`に以下を記載
```
　config.generators do |g|
      g.javascripts false
      g.helper false
      g.test_framework false
   end
```

## 動作確認方法
   -  rails g controller quiz indexをターミナルに打ち込む
   -  `app/controllers/quiz_controller.rb`が作成される
   -  `route get "quiz/index"`が記載される
   - `app/views/quiz`が作成される
   -  `app/views/quiz/index.html.erb`が作成される

 不要なテストフレームワークやhelperファイル等が作成されないことが確認されました。

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
-  #151 

## 参考資料
[rails generate controllerで不要なファイルを生成しない](https://qiita.com/tanakayo/items/5de57f4b89d1ef9c70ba)
