### PR TITLE
fix:config/application.rbの記載を変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,9 +17,9 @@ module Myapp
     config.autoload_lib(ignore: %w[assets tasks])
 
     config.generators do |g|
-      g.javascripts false
+      g.skip_routes true
       g.helper false
-      g.test_framework false
+      g.test_framework nil
     end
 
     # Configuration for the application, engines, and railties goes here.


### PR DESCRIPTION
## 概要
不要なファイルを作らないために`config/application.rb`の記載を変更

## 変更内容
- **修正**: `config/application.rb`の記載変更

**before**
```
config.generators do |g|
  g.javascripts false
  g.helper false
  g.test_framework false
end
```
**after**
```
config.generators do |g|
  g.skip_routes true
  g.helper false
  g.test_framework nil
end
```

## 関連Issue
- #151 
- #155 

