### PR TITLE
feat:仮言語別一覧ページの作成

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,4 @@
+class TagsController < ApplicationController
+  def index
+  end
+end

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,0 +1,1 @@
+<h1>(仮)app/views/tags/index.html.erb</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   resource :contacts, only: [ :new, :create ]
   resources :quiz_posts
+  get "tags/index"
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
## 概要
- 仮言語別一覧ページの作成

## 変更内容
**新規追加**: 
-  言語一覧ページの`app/controllers/tags_controller.rb`に`index`を追加
- 言語一覧ページ用の`app/views/tags/index.html.erb`を追加


## 関連Issue
-  #158 

## スクリーンショット
![image](https://github.com/user-attachments/assets/0617a7ca-bb65-448f-8174-34d0dc40ce71)
