### PR TITLE
feat:仮クイズ解説ページ

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,6 @@
 class QuestionsController < ApplicationController
   def show
   end
+  def result
+  end
 end

--- a/app/views/questions/_correct.html.erb
+++ b/app/views/questions/_correct.html.erb
@@ -1,0 +1,1 @@
+<h1>(仮)app/views/questions/questions/result_correct.html.erb</h1>

--- a/app/views/questions/_incorrect.html.erb
+++ b/app/views/questions/_incorrect.html.erb
@@ -1,0 +1,1 @@
+<h1>(仮)app/views/questions/questions/result_incorrect.html.erb</h1>

--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -1,0 +1,2 @@
+<%= render "correct" %>
+<%= render "incorrect" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :quiz_posts
   get "tags/index"
   resources :questions, only: [ :show ]
+  get "questions/result"
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 概要
仮クイズ解説ページの作成

## 変更内容
**新規追加**: 
-  クイズ解説ページの`app/controllers/questions_controller.rb`に`result`を追加
- クイズ解説ページの`app/views/questions/result.html.erb`を追加
- `app/views/questions/_correct.html.erb`と`app/views/questions/_incorrect.html.erb`のパーシャルを作成して、正解/不正解で表示ページを分ける事ができるように作成


## 関連Issue
-  #161 

## 備考
- まだidが作成できておらず、urlにアクセスできません（機能追加後は正常にアクセスできるはずです）
