### PR TITLE
fix:pushの記載を削除(Merge時にも通知が行くようになってしまっていたため)

### DIFF
--- a/.github/workflows/discord_notification.yaml
+++ b/.github/workflows/discord_notification.yaml
@@ -1,9 +1,6 @@
 name: discord-notification
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     branches:
       - stg


### PR DESCRIPTION
## 概要

- .github/workflows/discord_notification.yaml`からpushの記載を削除


## 変更内容
- **削除**: `.github/workflows/discord_notification.yaml`から下記の記載を削除
```
 push:
    branches:
      - develop
 ```