### PR TITLE
feat:developへのプルリクエスト自動化

### DIFF
--- a/.github/workflows/discord_notification.yaml
+++ b/.github/workflows/discord_notification.yaml
@@ -2,21 +2,19 @@ name: discord-notification
 
 on:
   pull_request:
+    types: [opened, closed]
     branches:
       - stg
       - develop
-  push:
-    branches:
-      - develop  # developブランチへのプッシュ時のみトリガー
 
 jobs:
   notify:
     name: Notify Discord
     runs-on: ubuntu-20.04
     steps:
-      - name: Discord Notification
+      - name: Notify on Pull Request Open
+        if: github.event.action == 'opened'
         uses: sarisia/actions-status-discord@v1
-        if: always() # 常に通知を送る
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           name: Discord Notification
@@ -25,18 +23,13 @@ jobs:
             Pull Request: ${{ github.event.pull_request.html_url || 'No URL' }}
             Author: ${{ github.event.pull_request.user.login || 'Unknown Author' }}
 
-  develop_push_notify:
-    name: Notify Discord for develop push
-    runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/develop'  # developブランチへのプッシュ時のみ実行
-    steps:
-      - name: Discord Notification
+      - name: Notify on Pull Request Close
+        if: github.event.action == 'closed'
         uses: sarisia/actions-status-discord@v1
-        if: always() # 常に通知を送る
         with:
           webhook: ${{ secrets.WORKING_TO_DEVELOP_WEBHOOK }}
           name: Discord Notification
-          title: ${{ github.event.head_commit.message || 'No Commit Message' }}
+          title: ${{ github.event.pull_request.title || 'No Title' }}
           description: |
-            Commit: ${{ github.event.head_commit.url || 'No URL' }}
-            Author: ${{ github.event.head_commit.author.name || 'Unknown Author' }}
+            Pull Request Closed: ${{ github.event.pull_request.html_url || 'No URL' }}
+            Author: ${{ github.event.pull_request.user.login || 'Unknown Author' }}


### PR DESCRIPTION
## 概要
- developブランチへのプルリク作成時と、developブランチへのプルリクmerge時に場合分けをし、それぞれのWEBHOOKでdiscord上に通知が行くようにしました

## 変更内容
- **修正**: 
- `.github/workflows/discord_notification.yaml`に下記記載を追記

トリガー

```
pull_request:
    types: [opened, closed]
    branches:
      - stg
      - develop
```

プルリク作成時

```
- name: Notify on Pull Request Open
        if: github.event.action == 'opened'
        uses: sarisia/actions-status-discord@v1
        if: always() # 常に通知を送る
        with:
          webhook: ${{ secrets.DISCORD_WEBHOOK }}
          name: Discord Notification
          title: ${{ github.event.pull_request.title || 'No Title' }}
          description: |
            Pull Request: ${{ github.event.pull_request.html_url || 'No URL' }}
            Author: ${{ github.event.pull_request.user.login || 'Unknown Author' }}
```

プルリクmerge時

```
- name: Notify on Pull Request Close
        if: github.event.action == 'closed'
        uses: sarisia/actions-status-discord@v1
        with:
          webhook: ${{ secrets.WORKING_TO_DEVELOP_WEBHOOK }}
          name: Discord Notification
          title: ${{ github.event.pull_request.title || 'No Title' }}
          description: |
            Pull Request Closed: ${{ github.event.pull_request.html_url || 'No URL' }}
            Author: ${{ github.event.pull_request.user.login || 'Unknown Author' }}

```

## 関連Issue
- #150 
- #188 



