### PR TITLE
fix:新規クイズ作成ページのレイアウト修正

### DIFF
--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -4,8 +4,7 @@
     <p class="text-sm text-primary ml-auto text-right">あとXX問作成です！</p>
   </div>
 
-
-  <div class="bg-secondary flex justify-center mx-48 mb-12">
+  <div class="flex bg-secondary rounded justify-center mx-48 mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-24">
       <div class="space-y-4">
         <div class="flex flex-col bg-white rounded p-6">
@@ -58,6 +57,7 @@
       </div>
       <button type="submit" class="text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6">登録する</button>
 
+      <!-- ページネーション -->
       <div class="flex justify-center gap-2 mt-6">
         <nav class="flex items-center gap-x-1" aria-label="Pagination">
           <button type="button" class="min-h-[32px] min-w-8 py-1.5 px-2 inline-flex jusify-center items-center gap-x-2 text-sm rounded-full text-primary hover:bg-gray-100 focus:outline-none focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none dark:text-white dark:hover:bg-white/10 dark:focus:bg-white/10" aria-label="Previous">


### PR DESCRIPTION
## 概要
- 新規クイズ作成ページのレイアウト修正

## 変更内容
- **修正**: bg-secondaryの部分にroundedを追加``(app/views/quiz_posts/new.html.erb)``

## 動作確認方法
1. **新規クイズ作成ページ**
   - [x] bg-secondaryの部分がroundedになっているか確認

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
- #13

## スクリーンショット
新規クイズ作成ページ
<img width="318" alt="スクリーンショット 2024-12-04 22 52 13" src="https://github.com/user-attachments/assets/2814722c-0b15-4de7-9866-04333984cc9a">