### PR TITLE
fix:新規クイズ作成ページのレイアウト修正(フォームの追加など)

### DIFF
--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -8,43 +8,11 @@
     <div class="flex flex-col w-full mt-6 mb-6 mx-24">
       <div class="space-y-4">
         <div class="flex flex-col bg-white rounded p-6">
-          <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary">クイズタイトル</h2>
+          <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary">クイズ集タイトル</h2>
           <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5" required />
         </div>
-        <div class="flex flex-col bg-white rounded p-6">
-          <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary">問題文</h2>
-          <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20"  required />
-        </div>
-        <div class="bg-white rounded p-6">
-          <div class="flex justify-between space-x-4 mb-6">
-            <div class="w-1/2">
-              <label for="回答1" class="block mb-2 text-lg font-medium text-primary">回答1</label>
-              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" required />
-            </div>  
-            <div class="w-1/2">
-              <label for="回答2" class="block mb-2 text-lg font-medium text-primary">回答2</label>
-              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" pattern="[0-9]{3}-[0-9]{2}-[0-9]{3}" required />
-            </div>
-          </div>
-          <div class="flex justify-between space-x-4 mt-4">
-            <div class="w-1/2">
-              <label for="回答3" class="block mb-2 text-lg font-medium text-primary">回答3</label>
-              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" required />
-            </div>
-            <div class="w-1/2">
-              <label for="回答4" class="block mb-2 text-lg font-medium text-primary">回答4</label>
-              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" required />
-            </div>
-          </div>
-        </div>
-        <div class="flex items-center bg-white rounded p-6 gap-8">
-          <h2 class="block text-lg text-nowrap font-medium text-primary">画像アップロード</h2>
-          <input
-          type="file"
-          class="file-input file-input-bordered file-input-primary file-input-sm w-full" />
-        </div> 
         <div class="bg-white rounded p-6 mb-6">
-          <label for="タグ" class="block mb-2 text-lg font-medium text-primary">タグ</label>
+          <label for="タグ" class="block mb-2 text-lg font-medium text-primary">クイズ集タグ</label>
           <div class="flex justify-between space-x-2">
             <button class="btn bg-html flex-1 text-lg text-white text-bold text-center text-nowrap">HTML</button>
             <button class="btn bg-css flex-1 text-lg text-white text-bold text-center text-nowrap">CSS</button>
@@ -54,43 +22,81 @@
             <button class="btn bg-error flex-1 text-lg text-white text-bold text-center text-nowrap">エラー</button>
           </div>
         </div>
+        <div class="divider"></div>
+        <div class="flex flex-col bg-white rounded p-6">
+          <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary">問題文</h2>
+          <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20"  required />
+        </div>
+        <div class="bg-white rounded p-6">
+          <div class="flex justify-between space-x-4 mb-6">
+            <div class="w-1/2">
+              <label for="回答1" class="block mb-2 text-lg font-medium text-primary">選択肢1</label>
+              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" required />
+            </div>
+            <div class="w-1/2">
+              <label for="回答2" class="block mb-2 text-lg font-medium text-primary">選択肢2</label>
+              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" required />
+            </div>
+          </div>
+          <div class="flex justify-between space-x-4 mt-4">
+            <div class="w-1/2">
+              <label for="回答3" class="block mb-2 text-lg font-medium text-primary">選択肢3</label>
+              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" required />
+            </div>
+            <div class="w-1/2">
+              <label for="回答4" class="block mb-2 text-lg font-medium text-primary">選択肢4</label>
+              <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" required />
+            </div>
+          </div>
+        </div>
+        <div class="bg-white rounded p-6">
+          <div class="flex flex-col justify-start">
+            <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary">正解</h2>
+            <select class="select select-bordered w-1/2">
+              <option disabled selected>正解の選択肢を選ぶ</option>
+              <option>選択肢1</option>
+              <option>選択肢2</option>
+              <option>選択肢3</option>
+              <option>選択肢4</option>
+            </select>
+          </div>
+        </div>
+        <div class="flex flex-col bg-white rounded p-6">
+          <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary">解説文</h2>
+          <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20"  required />
+        </div>
+        <div class="flex flex-col bg-white rounded p-6">
+          <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary">クイズ作成時の参考資料（URL）</h2>
+          <input type="text" class="bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5" required />
+        </div>
+        <div class="flex items-center bg-white rounded p-6 gap-8">
+          <h2 class="block text-lg text-nowrap font-medium text-primary">問題用 画像アップロード</h2>
+          <input
+          type="file"
+          class="file-input file-input-bordered file-input-primary file-input-sm w-full" />
+        </div>
+        <div class="flex items-center bg-white rounded p-6 gap-8">
+          <h2 class="block text-lg text-nowrap font-medium text-primary">回答用 画像アップロード</h2>
+          <input
+          type="file"
+          class="file-input file-input-bordered file-input-primary file-input-sm w-full" />
+        </div>
       </div>
       <button type="submit" class="text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6">登録する</button>
 
       <!-- ページネーション -->
       <div class="flex justify-center gap-2 mt-6">
-        <nav class="flex items-center gap-x-1" aria-label="Pagination">
-          <button type="button" class="min-h-[32px] min-w-8 py-1.5 px-2 inline-flex jusify-center items-center gap-x-2 text-sm rounded-full text-primary hover:bg-gray-100 focus:outline-none focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none dark:text-white dark:hover:bg-white/10 dark:focus:bg-white/10" aria-label="Previous">
-            <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="m15 18-6-6 6-6"></path>
-            </svg>
-            <span class="sr-only">Previous</span>
-          </button>
-          <div class="flex items-center gap-x-1">
-            <button type="button" class="min-h-[32px] min-w-8 flex justify-center items-center bg-primary text-white py-1.5 px-2.5 text-sm rounded-full focus:outline-none focus:bg-gray-300 disabled:opacity-50 disabled:pointer-events-none" aria-current="page">1</button>
-            <button type="button" class="min-h-[32px] min-w-8 flex justify-center items-center text-primary hover:bg-gray-100 py-1.5 px-2.5 text-sm rounded-full focus:outline-none focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none">2</button>
-            <button type="button" class="min-h-[32px] min-w-8 flex justify-center items-center text-primary hover:bg-gray-100 py-1.5 px-2.5 text-sm rounded-full focus:outline-none focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none">3</button>
-            <div class="hs-tooltip inline-block">
-              <button type="button" class="hs-tooltip-toggle group min-h-[32px] min-w-8 flex justify-center items-center text-primary hover:text-blue-600 p-1 text-sm rounded-full focus:outline-none focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none">
-                <span class="text-[10px] group-hover:hidden">•••</span>
-                <svg class="group-hover:block hidden shrink-0 size-5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="m6 17 5-5-5-5"></path>
-                  <path d="m13 17 5-5-5-5"></path>
-                </svg>
-                <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 transition-opacity inline-block absolute invisible z-10 py-1 px-2 bg-gray-900 text-xs font-medium text-white rounded shadow-sm" role="tooltip">
-                  Next 4 pages
-                </span>
-              </button>
-            </div>
-            <button type="button" class="min-h-[32px] min-w-8 flex justify-center items-center text-primary hover:bg-gray-100 py-1.5 px-2.5 text-sm rounded-full focus:outline-none focus:bg-primary disabled:opacity-50 disabled:pointer-events-none">10</button>
-          </div>
-          <button type="button" class="min-h-[32px] min-w-8 py-1.5 px-2 inline-flex jusify-center items-center gap-x-2 text-sm rounded-full text-primary hover:bg-gray-100 focus:outline-none focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none" aria-label="Next">
-            <span class="sr-only">Next</span>
-            <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="m9 18 6-6-6-6"></path>
-            </svg>
-          </button>
-        </nav>
+        <div class="join mt-6">
+          <button class="join-item btn btn-sm bg-primary text-base-100">1</button>
+          <button class="join-item btn btn-sm bg-accent text-base-100">2</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">3</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">4</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">5</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">6</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">7</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">8</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">9</button>
+          <button class="join-item btn btn-sm bg-primary text-base-100">10</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- 新規クイズ作成ページのレイアウト修正(フォームの追加など)

## 変更内容
- **修正**: フォームを追加 (`app/views/quiz_posts/new.html.erb`)
  - 正解の選択肢
  - 解説文
  - クイズ作成時の参考資料(URL)
  - 解説用 画像アップロード
- **修正**: ページネーションのデザインを変更

## 動作確認方法
<!-- どのように動作確認を行ったか、具体的な手順を記載 -->
1. **新規クイズ作成ページ**
   - [x]  画面遷移図を参照しレイアウトを確認

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
- #13

## スクリーンショット
新規クイズ作成ページ
![localhost_3000_quiz_posts_new (8)](https://github.com/user-attachments/assets/b9de63fa-c210-4296-ad8a-8f2053de9d5a)