### PR TITLE
fix:新規クイズ作成ページのレイアウト修正(登録ボタンとページネーションの入れ替え)

### DIFF
--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -81,22 +81,24 @@
           type="file"
           class="file-input file-input-bordered file-input-primary file-input-sm w-full" />
         </div>
-      </div>
-      <button type="submit" class="text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6">登録する</button>
-
-      <!-- ページネーション -->
-      <div class="flex justify-center gap-2 mt-6">
-        <div class="join mt-6">
-          <button class="join-item btn btn-sm bg-primary text-base-100">1</button>
-          <button class="join-item btn btn-sm bg-accent text-base-100">2</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">3</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">4</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">5</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">6</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">7</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">8</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">9</button>
-          <button class="join-item btn btn-sm bg-primary text-base-100">10</button>
+        <!-- ページネーション -->
+        <div class="flex justify-center gap-2">
+          <div class="join mt-6">
+            <button class="join-item btn btn-sm bg-primary text-base-100">1</button>
+            <button class="join-item btn btn-sm bg-accent text-base-100">2</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">3</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">4</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">5</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">6</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">7</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">8</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">9</button>
+            <button class="join-item btn btn-sm bg-primary text-base-100">10</button>
+          </div>
+        </div>
+        <div class="flex justify-center">
+          <button type="submit" class="text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6">登録する</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- 新規クイズ作成ページのレイアウト修正(登録ボタンとページネーションの入れ替え)

## 変更内容
- **修正**: 登録ボタンとページネーションの上下を入れ替え``(app/views/quiz_posts/new.html.erb)``

## 動作確認方法
1. **新規クイズ作成ページ**
   - [x] 画面遷移図を参照しレイアウトを確認

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
- #13

## スクリーンショット
新規クイズ作成ページ
<img width="927" alt="スクリーンショット 2024-12-07 0 44 16" src="https://github.com/user-attachments/assets/20a0fe69-2431-4400-ba01-d5e8e0051e0d">