### PR TITLE
fix:HTMLの文字の大きさを統一

### DIFF
--- a/app/views/rankings/index.html.erb
+++ b/app/views/rankings/index.html.erb
@@ -183,7 +183,7 @@
             <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary' %>
             <p class="text-sm">ユーザーネーム</p>
           </div>
-          <button class="btn btn-xs bg-html flex-1 text-sm text-white font-bold text-center text-nowrap mt-1 ">HTML</button>
+          <button class="btn btn-xs bg-html flex-1  text-white text-bold px-3 mt-2 text-center text-nowrap ">HTML</button>
           <!-- 星評価 -->
           <div class="text-primary">
             ★★★★★
@@ -203,7 +203,7 @@
             <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary' %>
             <p class="text-sm">ユーザーネーム</p>
           </div>
-           <button class="btn btn-xs bg-html flex-1 text-sm text-white font-bold text-center text-nowrap mt-1 ">HTML</button>
+           <button class="btn btn-xs bg-html flex-1  text-white text-bold px-3 mt-2 text-center text-nowrap">HTML</button>
           <div class="text-primary">
             ★★★★☆
           </div>
@@ -222,7 +222,7 @@
            <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary' %>
             <p class="text-sm">ユーザーネーム</p>
           </div>
-           <button class="btn btn-xs bg-html flex-1 text-sm text-white font-bold text-center text-nowrap mt-1 ">HTML</button>
+           <button class="btn btn-xs bg-html flex-1  text-white text-bold px-3 mt-2 text-center text-nowrap ">HTML</button>
           <div class="text-primary">
             ★★★★☆
           </div>
@@ -241,7 +241,7 @@
            <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary' %>
             <p class="text-sm">ユーザーネーム</p>
           </div>
-           <button class="btn btn-xs bg-html flex-1 text-sm text-white font-bold text-center text-nowrap mt-1 ">HTML</button>
+           <button class="btn btn-xs bg-html flex-1  text-white text-bold px-3 mt-2 text-center text-nowrap ">HTML</button>
           <div class="text-primary">
             ★★★☆☆
           </div>
@@ -260,7 +260,7 @@
             <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary' %>
             <p class="text-sm">ユーザーネーム</p>
           </div>
-          <button class="btn btn-xs bg-html flex-1 text-sm text-white font-bold text-center text-nowrap mt-1 ">HTML</button>
+          <button class="btn btn-xs bg-html flex-1  text-white text-bold px-3 mt-2 text-center text-nowrap  ">HTML</button>
           <div class="text-primary">
             ★★★☆☆
           </div>


### PR DESCRIPTION
## 概要
- HTMLの大きさをたくさん解かれたクイズとレビューが高評価のクイズで合わせる

## 変更内容
- **修正**: HTMLの文字のクラスを`class="btn btn-xs bg-html flex-1  text-white text-bold px-3 mt-2 text-center text-nowrap"`に変更

## 動作確認方法
1. **localhostで画面表示**
   - [ ] locahost3000でHTMLの文字サイズを確認


## スクリーンショット（任意）
![image](https://github.com/user-attachments/assets/ab4c0d5a-7f1a-4a24-bb00-748ad8598cde)

