### PR TITLE
add:render-build.shファイルの追加

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,6 @@
+set -o errexit
+
+bundle install
+bundle exec rake assets:precompile
+bundle exec rake assets:clean
+bundle exec rake db:migrate


### PR DESCRIPTION
## 概要

- bin/render-build.shが存在しなくなってしまっていたようなので、再作成しました

- Renderのlogsにて、`PG::UndefinedTable (ERROR:  relation "contacts" does not exist
LINE 10:  WHERE a.attrelid = '"contacts"'::regclass
                             ^
)`のエラーが発生

- bin/render-build.shの中に、記載するべきデータベースをmigrateするための記述`bundle exec rake db:migrate`が抜けていることが分かった(そもそもファイルが紛失していたため) 

## 変更内容
<!-- 具体的な変更内容や追加した機能について箇条書きで記載 -->
- **新規追加**: bin/render-build.shファイルの作成（最初のdeploy時に作った気がするんですけど、消えていたため）

## 備考
- 記載内容
```
set -o errexit
エラー時にスクリプトを停止します。安全なビルドを保証。
bundle install
Gemの依存関係をインストールします。
bundle exec rake assets:precompile
Railsの静的アセットをプリコンパイルします（本番環境用）。
bundle exec rake assets:clean
不要な古いアセットを削除します。
bundle exec rake db:migrate
データベースに最新のマイグレーションを適用します。

```

## 参考資料
[Renderでのデプロイが失敗した時の確認](https://qiita.com/hashioga2017/items/b69cb070c0073e9c26c7)