### PR TITLE
fix:本番環境エラー対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,15 +104,14 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
 
-  config.action_mailer.default_url_options = { host: "https://programing-quiz-1.onrender.com", protocol: "https" }
+  host = "programing-quiz-1.onrender.com"
+  config.action_mailer.default_url_options = { host: host, protocol: "https" }
   config.action_mailer.raise_delivery_errors = true
-
   config.action_mailer.delivery_method = :smtp
-
   config.action_mailer.smtp_settings = {
     address: "smtp.gmail.com",
     port: 587,
-    domain: "https://programing-quiz-1.onrender.com",
+    domain: "gmail.com",
     user_name:            ENV["GMAIL_USERNAME"],
     password:             ENV["GMAIL_PASSWORD"],
     authentication: "plain",


### PR DESCRIPTION
## 概要
- お問い合わせ送信時に本番環境でエラーが出る事象の対応を実施

## 変更内容
- **修正**: production.rbの記載を修正

## 動作確認方法
本番環境の対応のため、動作確認できていません。

## 関連Issue
- close #259 

## 参考資料
- [[Rails]deviseのパスワードリセット機能](https://zenn.dev/yuna0960740/articles/12d33231b8a961#%E7%92%B0%E5%A2%83%E3%81%AE%E8%A8%AD%E5%AE%9A(%E6%9C%AC%E7%95%AA%E7%92%B0%E5%A2%83))