### PR TITLE
fix:TOPページのキャラクター配置を修正

### DIFF
--- a/app/views/quiz_posts/index.html.erb
+++ b/app/views/quiz_posts/index.html.erb
@@ -169,7 +169,7 @@
             <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
           </div>
         </div>
-        <%= image_tag "duck_body.png", class: 'mt-4' %>
-    </div>
+      </div>
+    <%= image_tag "duck_body.png", class: 'mt-4' %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
TOPページのキャラクター画像がランキング（レビューが高評価のクイズ）のクイズカードに入り込んでいた為、修正。

## 変更内容
- **修正**: TOPページのキャラクター配置を修正（`app/views/quiz_posts/index.html.erb`）

## 動作確認方法
1. **TOPページ**
 画面遷移図を参照しレイアウトを確認

## スクリーンショット（任意）
**[TOPページ Before]**
![スクリーンショット 2024-12-13 13 15 39](https://github.com/user-attachments/assets/824e68c2-5a5d-45cb-a385-bc8d4253c93d)

**[TOPページ After]**
![スクリーンショット 2024-12-13 13 16 04](https://github.com/user-attachments/assets/2b28f79a-28d3-4be3-a65d-738f79e7c5c0)

