### PR TITLE
feat:お問い合わせページのデザイン追加

### DIFF
--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,42 +1,45 @@
-<h1>(仮)app/views/contacts/new.html.erb</h1>
+<div class="bg-white">
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <h1 class="text-3xl font-bold text-accent text-center">お問い合わせ</h1>
+  </div>
 
-<br>
-<br>
-<br>
-<% if @contact.errors.any? %>
-  <ul>
-    <% @contact.errors.full_messages.each do |error| %>
-      <li><%= error %></li>
-    <% end %>
-  </ul>
-<% end %>
-
-<br>
-<br>
-<br>
-
-<div>
-  <%= form_with model: @contact do |f| %>
-    <div>
-      <%= f.label :name %>
-      <%= f.text_field :name %>
-    </div>
-    <div>
-      <%= f.label :email %>
-      <%= f.text_field :email %>
-    </div>
-    <div>
-      <%= f.label :title %>
-      <%= f.text_field :title %>
-    </div>
-    <div>
-      <%= f.label :text %>
-      <%= f.text_field :text %>
-    </div>
-
-    <%= f.submit "送信" %>
+  <% if @contact.errors.any? %>
+    <ul>
+      <% @contact.errors.full_messages.each do |error| %>
+        <li><%= error %></li>
+      <% end %>
+    </ul>
   <% end %>
+
+  <div class="flex bg-secondary rounded justify-center mx-48 mb-12">
+    <div class="flex flex-col w-full mt-6 mb-6 mx-24">
+      <div class="space-y-4">
+        <%= form_with model: @contact do |f| %>
+          <div class="flex flex-col bg-white rounded p-6">
+            <%= f.label :name, class: 'block mb-2 text-lg text-nowrap font-medium text-primary' %>
+            <%= f.text_field :name, class: 'bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary block p-2.5', placeholder: "20文字以内", required: true %>
+          </div>
+          <div class="flex flex-col bg-white rounded p-6">
+            <%= f.label :email, class: 'block mb-2 text-lg text-nowrap font-medium text-primary' %>
+            <%= f.text_field :email, class: 'bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary block p-2.5', placeholder: "example＠com", required: true %>
+          </div>
+          <div class="flex flex-col bg-white rounded p-6">
+            <%= f.label :title, class: 'block mb-2 text-lg text-nowrap font-medium text-primary' %>
+            <%= f.text_field :title, class: 'bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary block p-2.5', placeholder: "100文字以内", required: true %>
+          </div>
+          <div class="flex flex-col bg-white rounded p-6">
+            <%= f.label :text, class: 'block mb-2 text-lg text-nowrap font-medium text-primary' %>
+            <%= f.text_area :text,
+                class: 'bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary block p-2.5',
+                placeholder: "2000文字以内",
+                required: true,
+                rows: 5 %>
+          </div>
+          <div class="flex justify-center">
+          <%= f.submit "送信する", class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>
-
-
-*****


### PR DESCRIPTION
## 概要
#233  で作成したお問い合わせページのビューに対するデザイン追加を行いました。

## 変更内容
- **新規追加**: お問い合わせページのデザイン追加(`app/views/contacts/new.html.erb`)

## 動作確認方法
1. **お問い合わせページ**
   - [X]  画面遷移図と`http://localhost:3000/contacts/new`を照らし合わせレイアウトを確認

## 関連Issue
- #24 

## スクリーンショット（任意）
  - **お問い合わせページ**
![スクリーンショット 2024-12-16 14 18 50](https://github.com/user-attachments/assets/5bfee050-bb5d-4e0c-bb19-af9375e0d64e)