### PR TITLE
fix:新規登録ページのレイアウト修正

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -54,8 +54,7 @@
 
       <!-- リンク表示 -->
       <div class="flex flex-col items-center space-y-2 text-sm md:text-lg">
-        <%= link_to t('devise.registrations.new.login'), new_user_session_path, class: 'text-primary font-bold hover:text-primary hover:text-opacity-70 transition duration-300' %>
-        <%= link_to t('devise.registrations.new.forgot_password'), new_user_password_path, class: 'text-primary font-bold hover:text-primary hover:text-opacity-70 transition duration-300' %>
+        <%= render "devise/shared/links" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- 新規登録ページのレイアウト修正(``app/views/devise/registrations/new.html.erb``)

## 変更内容
- **修正**: 新規登録ページのレンダリングに``app/views/devise/shared/_links.html.erb``を使用
- **修正**: 新規登録ページには「パスワードをお忘れの方はこちら」を表示しない

## 動作確認方法
1. **新規登録ページ**
   - [ ] 「登録する」ボタンの下に「ログイン」リンクが表示されている

## 関連Issue
- #4

## スクリーンショット
新規登録ページ
![localhost_3000_users_sign_up](https://github.com/user-attachments/assets/f38ef52c-8bb1-437b-b955-36690df2e0b2)