### PR TITLE
fix:Renderのデータベースをリセット

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,5 +3,6 @@ set -o errexit
 bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-bundle exec rake db:migrate
+# bundle exec rake db:migrate
 bundle exec rake db:seed
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset


### PR DESCRIPTION
## 概要
bin/render-build.shに`bundle exec rake db:migrate`をコメントアウトして、`DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset`を記載し、一時的にRenderのデータベースをリセットしました

## 変更内容

- 修正：`bundle exec rake db:migrate`をコメントアウトして無効化
- 修正：`DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset`を記載


## 参考資料
[《Rails》renderでの本番環境でのマイグレーションの注意【初学者のオリアプ作成】](https://zenn.dev/d_miyabi/articles/0ce427f40d2306)