### PR TITLE
fix:新規クイズ作成ページの残り問題数表示を修正

### DIFF
--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -1,8 +1,11 @@
 <div class="bg-white">
   <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
     <h1 class="text-3xl font-bold text-accent text-center">新規クイズ作成</h1>
-    <p class="text-sm text-primary ml-auto text-right">あとXX問作成です！</p>
-  </div>
+    <div class="flex items-center text-sm text-primary ml-auto text-right mt-2">
+      <%= image_tag 'duck_body.png', class: 'h-10 w-10 mr-2' %>
+      <p>1問〜10問 作成可能だよ！</p>
+    </div>
+</div>
 
   <div class="flex bg-secondary rounded justify-center mx-48 mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-24">


### PR DESCRIPTION
## 概要
新規クイズ作成ページの残り問題数表示を修正しました。

**[before]**
あとXX問作成です

**[after]**
1問〜10問 作成可能だよ！

## 変更内容
- **修正**: 新規クイズ作成ページの残り問題数表示を修正（`app/views/quiz_posts/new.html.erb`）

## 動作確認方法
1. **新規クイズ作成ページ**
 画面遷移図と`localhost:3000/quiz_posts/new`を照らし合わせレイアウトを確認

## 関連Issue
- #293

## スクリーンショット（任意）
![スクリーンショット 2024-12-26 17 55 07](https://github.com/user-attachments/assets/259bf317-0687-44d6-a9f7-c3ad992dd8d6)


