### PR TITLE
fix:新規登録ページの（6文字以上）を削除

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -26,9 +26,6 @@
         <!-- パスワード入力 -->
         <div class="mt-4 md:mt-8">
           <%= f.label :password, t('devise.registrations.new.password'), class: 'block mb-2 text-sm md:text-lg text-nowrap font-medium text-primary' %>
-          <% if @minimum_password_length %>
-            <em class="text-xs text-gray-500">(<%= @minimum_password_length %> <%= t('.characters_minimum') %>)</em>
-          <% end %>
           <%= f.password_field :password, class: 'bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary block p-2 md:p-3.5', placeholder: t('devise.registrations.new.password_placeholder'), required: true, autocomplete: "new-password", id: "password_field" %>
           <div class="mt-2">
             <%= check_box_tag 'show_password', '1', false, onclick: 'togglePasswordVisibility()' %>


### PR DESCRIPTION
## 概要
- 新規登録ページのレイアウト修正(app/views/devise/registrations/new.html.erb)

## 変更内容
- **修正**: パスワードのフォーム外の（6文字以上）を削除

## 動作確認方法
1. **新規登録ページ**
   - [ ] パスワードのフォーム外の（6文字以上）が削除されている

## 関連Issue
- #330

## スクリーンショット
新規登録ページのパスワード欄
- 修正前
<img width="499" alt="スクリーンショット 2024-12-27 12 15 39" src="https://github.com/user-attachments/assets/7570a9a7-7320-4174-8e6d-c04b5b0e1030" />

- 修正後
<img width="986" alt="スクリーンショット 2024-12-27 12 10 25" src="https://github.com/user-attachments/assets/1f3a7c86-4be1-4e56-8cb0-bac8fc023525" />