### PR TITLE
delete:goggleログイン画像のコメントアウト

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -43,30 +43,35 @@
           </div>
         <%# end %>
 
+
         <div class="mt-8 md:mt-12 flex justify-center">
           <%= f.submit t('.sign_in'), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-64 px-5 py-2.5 text-center' %>
         </div>
       <% end %>
-      <div class="divider">または</div>
 
-      <div class="mt-8 md:mt-12 flex justify-center">
-        <button class="gsi-material-button" style="width:255px">
-          <div class="gsi-material-button-state"></div>
-          <div class="gsi-material-button-content-wrapper">
-            <div class="gsi-material-button-icon">
-              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" xmlns:xlink="http://www.w3.org/1999/xlink" style="display: block;">
-                <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
-                <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
-                <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
-                <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
-                <path fill="none" d="M0 0h48v48H0z"></path>
-              </svg>
-            </div>
-            <span class="gsi-material-button-contents">Sign in with Google</span>
-            <span style="display: none;">Sign in with Google</span>
+    <!-- MVPリリースでは表示させないため、コメントアウト
+    <div class="divider">または</div>
+
+    <div class="mt-8 md:mt-12 flex justify-center">
+      <button class="gsi-material-button" style="width:255px">
+        <div class="gsi-material-button-state"></div>
+        <div class="gsi-material-button-content-wrapper">
+          <div class="gsi-material-button-icon">
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" xmlns:xlink="http://www.w3.org/1999/xlink" style="display: block;">
+              <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+              <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+              <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+              <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+              <path fill="none" d="M0 0h48v48H0z"></path>
+            </svg>
           </div>
-        </button>
-      </div>
+          <span class="gsi-material-button-contents">Sign in with Google</span>
+          <span style="display: none;">Sign in with Google</span>
+        </div>
+      </button>
+    </div>
+    -->
+
 
       <div class="flex flex-col items-center space-y-2 text-sm md:text-lg">
         <%= render "devise/shared/links" %>


### PR DESCRIPTION
## 概要
ログインページのgoggleログイン画像のコメントアウトを行いました。
（本リリース実装部分であり、MVP時点では画面表示を行わないことになった為）

## 変更内容
- **削除**: goggleログイン画像のコメントアウト（`app/views/devise/sessions/new.html.erb`）

## 動作確認方法
1. **ログインページ**
   - [X] `localhost:3000/users/sign_in`で、goggleログイン画像が表示されていないことを確認

## 関連Issue
- #329

## スクリーンショット（任意）
![スクリーンショット 2024-12-27 15 06 44](https://github.com/user-attachments/assets/394e6767-fb7c-4ee8-b7df-03cc22af28f6)

## 備考
- バックチームがgoggle認証を実装する前に、こちらの画像はフロントチームの方でコメントアウトを外させて頂きます。