### PR TITLE
feat:プライバシーポリシーを追加

### DIFF
--- a/app/views/privacy_policies/index.html.erb
+++ b/app/views/privacy_policies/index.html.erb
@@ -1,1 +1,61 @@
-<h1>(仮)app/views/privacy_policies/index.html.erb</h1>
+<div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+  <h1 class="text-3xl font-bold text-accent text-center">プライバシーポリシー</h1>
+</div>
+
+<div class="container mx-auto pt-3 px-12 py-24">
+  <div class="mb-6">
+    <h2 class="mb-2 text-lg font-bold text-primary">お客様から取得する情報</h2>
+    <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から以下の情報を取得します。</p>
+    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+      <li>氏名(ニックネームやペンネームも含む)</li>
+      <li>メールアドレス</li>
+      <li>写真</li>
+      <li>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+      <li>Cookie(クッキー)を用いて生成された識別情報</li>
+      <li>当サービスのウェブサイトの滞在時間、入力履歴等の当社ウェブサイトにおけるお客様の行動履歴</li>
+      <li>当サービスの起動時間、入力履歴等の利用履歴</li>
+    </ul>
+  </div>
+
+  <div class="mb-6">
+    <h2 class="mb-2 text-lg font-bold text-primary">お客様の情報を利用する目的</h2>
+    <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から取得した情報を、以下の目的のために利用します。</p>
+    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+      <li>当サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+      <li>お客様の当サービスの利用履歴を管理するため</li>
+      <li>当サービスにおけるお客様の行動履歴を分析し、当サービスの維持改善に役立てるため</li>
+      <li>お客様からのお問い合わせに対応するため</li>
+      <li>規約や法令に違反する行為に対応するため</li>
+      <li>変更、提供中止、終了、契約解除をご連絡するため</li>
+      <li>当サービス規約の変更等を通知するため</li>
+      <li>以上の他、当サービスの提供、維持、保護及び改善のため</li>
+    </ul>
+  </div>
+
+  <div class="mb-6">
+    <h2 class="mb-2 text-lg font-bold text-primary">安全管理のために講じた措置</h2>
+    <p class="mb-2 text-sm leading-7 text-gray-700">当サービスが、お客様から取得した情報に関して安全管理のために講じた措置につきましては、お問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
+  </div>
+
+  <div class="mb-6">
+    <h2 class="mb-2 text-lg font-bold text-primary">第三者提供</h2>
+    <p class="text-sm leading-7 text-gray-700">当サービスは、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
+  </div>
+
+  <div class="mb-6">
+    <h2 class="mb-2 text-lg font-bold text-primary">アクセス解析ツール</h2>
+    <p class="text-sm leading-7 text-gray-700">当サービスは、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。</p>
+    <p class="text-sm leading-7 text-gray-700">Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。</p>
+    <p class="mb-2 text-sm leading-7 text-gray-700">Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
+    <%= link_to "Googleアナリティクス利用規約（外部サイト）", "https://marketingplatform.google.com/about/analytics/terms/jp/", target: "_blank", class: "link link-primary text-sm" %>
+  </div>
+
+  <div class="mb-8">
+    <h2 class="mb-2 text-lg font-bold text-primary">プライバシーポリシーの変更</h2>
+    <p class="text-sm leading-7 text-gray-700">当サービスは、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+  </div>
+
+  <div class="flex justify-end">
+    <p class="text-sm text-gray-700">2025年1月1日 制定</p>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
- プライバシーポリシーを追加

## 変更内容
- **新規追加**: プライバシーポリシーの内容とレイアウト (`app/views/privacy_policies/index.html.erb`)

## 動作確認方法
1. **プライバシーポリシー**
   - [ ] 所定の内容が表示されている
 
## 関連Issue
- #30

## スクリーンショット
![localhost_3000_privacy_policies (4)](https://github.com/user-attachments/assets/ca1fb138-be04-4f12-974a-719aac7af135)

## 備考
- 内容に誤字・脱字がないか、1行ずつご確認いただけますと幸いです