### PR TITLE
fix:brakemanのアップデート（CIのscan_rubyの修正）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.2)
+    brakeman (7.0.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
## 概要
`bundle update brakeman`をして、scan_rubyの修正を試みました

## 変更内容
- **修正**: `bundle update brakeman`をして`Using brakeman 7.0.0 (was 6.2.2)`にアップデート


## 関連Issue
- #347 

## 備考
- Gemfile.lockの書き換えを行ったため、もしかしたらやらないほうがいい変更かもです（レビューの際ご検討いただいて、修正しないほうが良さそうであればその旨教えて下さい）