### PR TITLE
fix:ヘッダーを固定、フッターの固定を解除

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
   <body class="font-mplus">
     <%= render 'shared/header' %>
     <%= render 'devise/shared/flash_messages' %>
-    <main>
+    <main class="pt-24">
     <%= yield %>
     </main>
     <%= render 'shared/footer' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-secondary fixed bottom-0 w-full">
+<div class="bg-secondary w-full">
   <div class="ml-5 mx-auto flex justify-between items-center p-4">
     <div class="flex space-x-4">
       <%= link_to 'お問い合わせ', new_contacts_path, class: 'text-primary font-bold' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-secondary">
+<div class="bg-secondary fixed top-0 w-full z-50">
   <div class="ml-5 mx-auto flex justify-between items-center p-4">
     <div class="flex items-center space-x-4">
       <%= image_tag 'logo.png', class: 'w-10 h-10' %>


### PR DESCRIPTION
## 概要
- ヘッダーを固定、フッターの固定を解除

## 変更内容
- **修正**: ヘッダーを固定 (`app/views/shared/_header.html.erb`)
- **修正**: フッターの固定を解除 (`app/views/shared/_footer.html.erb`)
- **追加**: コンテンツ上部にヘッダー分の余白を追加 (`app/views/layouts/application.html.erb`)

## 動作確認方法
1. **ヘッダーとフッターの設定**
   - [ ] ヘッダーが固定されている
   - [ ] フッターが固定されていない
   - [ ] ヘッダーとコンテンツが重なっていない

## 関連Issue
- #364

## スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/5ad756e50ce32155a95a42000ac87906.gif)](https://gyazo.com/5ad756e50ce32155a95a42000ac87906)