### PR TITLE
fix:クイズ解説ページ レビュー機能のコメントアウト

### DIFF
--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -93,6 +93,7 @@
             <% end %>
           </div>
           <% else %>
+          <!-- （本リリース）レビュー機能　
           <div class="mt-12 p-8 bg-accent bg-opacity-30 rounded">
             <p class="text-primary text-xl">この問題はどうでしたか？</p>
             <p class="text-xs">レビュー投稿しても自身のユーザーネームは公開されません！</p>
@@ -109,11 +110,13 @@
               <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
               <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
             </div>
+
             <div class="mt-6 flex justify-center items-center">
               <button type="submit"
                 class="text-white bg-primary hover:opacity-70 font-medium rounded-lg w-full sm:w-auto px-3 py-1.5 text-center">レビューを投稿する
               </button>
             </div>
+            -->
           </div>
           <div class="flex justify-center items-center mt-12 space-x-4">
             <%= link_to "/", class: "text-white bg-accent hover:opacity-70 rounded-lg text-lg px-5 py-2.5 flex items-center justify-center gap-2 w-64" do %>


### PR DESCRIPTION
## 概要
クイズ解説ページ レビュー機能のコメントアウトをしました。
（レビュー機能は本リリース実装の為）

## 変更内容
- **修正**: レビュー機能のコメントアウト（`app/views/questions/result.html.erb`）

## 動作確認方法
1. **クイズ解説ページ**
   - [X] `localhost:3000/questions/1/result`を表示し、レビュー機能のレイアウトが削除されているか確認

## 関連Issue
- #366

## スクリーンショット（任意）
![スクリーンショット 2025-01-15 10 05 33](https://github.com/user-attachments/assets/fcc0eb4a-2011-471f-b78c-4c64a6a0465e)