### PR TITLE
一時的にバリデーションを無効化してシードデータの投入を可能に

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,7 +7,7 @@ class Question < ApplicationRecord
 
   # 入力があればバリデーションを実行
   validates :question, presence: true, if: :required_question?
-  validate :validate_correct_answer_and_choices
+  # validate :validate_correct_answer_and_choices
 
 
 

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -7,7 +7,7 @@ class Quiz < ApplicationRecord
   has_many :tags, through: :tag_quizzes
 
   validates :title, presence: true
-  validate :at_least_one_question
+  # validate :at_least_one_question
 
   private
 


### PR DESCRIPTION
## 概要
- シードデータを本番環境に投入するため、一時的にバリデーションを無効化する修正を実装

## 変更内容
<!-- 具体的な変更内容や追加した機能について箇条書きで記載 -->
- ** 一時無効化**: Quiz modelの質問数バリデーションをコメントアウト
- ** 一時無効化**: Question modelの選択肢バリデーションをコメントアウト

## 動作確認方法
1. **シードデータの投入**
   - [ ] bundle exec rails db:seedを実行し、エラーなく完了する
   - [ ] 管理者ユーザーが正しく作成される
   - [ ] サンプルクイズが正しく作成される
2. **アプリケーションの動作**
   - [ ] シードデータ投入後もアプリケーションが正常に動作する
   - [ ] 既存のクイズデータが正しく表示される

## 備考
- この修正は一時的なものであり、シードデータ投入後は再度バリデーションを有効化する予定