### PR TITLE
fix:TOPページ ランキング部分のコメントアウト

### DIFF
--- a/app/views/quiz_posts/index.html.erb
+++ b/app/views/quiz_posts/index.html.erb
@@ -41,6 +41,7 @@
       </h2>
     <% end %>
 
+    <!-- （本リリース）ランキング機能
     <div class="bg-secondary p-6 rounded shadow mt-12">
       <h2 class="text-primary text-xl font-bold mb-2 flex items-center">
         <span class="material-icons">
@@ -97,3 +98,4 @@
     </div>
   </div>
 </div>
+-- !>


### PR DESCRIPTION
## 概要
TOPページ ランキング部分のコメントアウトをしました。
（ランキング機能は本リリース実装の為）

## 変更内容
- **修正**: ランキング部分のコメントアウト（`app/views/quiz_posts/index.html.erb`）

## 動作確認方法
1. **TOPページ**
   - [X] `localhost:3000`を表示し、ランキング部分のレイアウトが削除されているか確認

## 関連Issue
- #365

## スクリーンショット（任意）
![スクリーンショット 2025-01-16 10 58 27](https://github.com/user-attachments/assets/222ae017-5824-46ca-a41e-c694a1a783cd)

