### PR TITLE
fix:新着クイズにおけるプロフィール画像の動的反映

### DIFF
--- a/app/views/quiz_posts/_quiz_card.html.erb
+++ b/app/views/quiz_posts/_quiz_card.html.erb
@@ -2,10 +2,18 @@
   <p class="text-accent text-lg">
     <%= link_to quiz.title, quiz_post_path(quiz.id) %>
   </p>
-  <%= link_to user_profile_path(quiz.user.id), class: "flex items-center gap-2" do %>
-    <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary border--300' %>
-    <p><%= quiz.user&.name || "作者不明" %></p>
-  <% end %>
+ <!-- 作成者情報 -->
+  <div class="flex gap-1 items-center">
+    <% if quiz.user&.profile&.user_icon&.attached? %>
+      <%= image_tag quiz.user.profile.user_icon, class: 'w-6 h-6 rounded-full object-cover border border-primary border--300' %>
+    <% else %>
+      <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary border--300' %>
+    <% end %>
+    <%= link_to user_profile_path(quiz.user.id), class: "flex items-center gap-2" do %>
+      <p><%= quiz.user&.name || "作者不明" %></p>
+    <% end %>
+  </div>
+  <!-- タグと日付 -->
   <div class="flex mt-2">
     <%= render partial: "tags/buttons/tags", locals: { tags: quiz.tags } %>
     <p class="ml-2"><%= quiz.created_at.strftime('%Y/%m/%d') %></p>


### PR DESCRIPTION
## 概要
- トップページの新着クイズにおけるユーザーアイコンの表示ロジックを追加

## 変更内容
- **修正**: トップページの新着クイズにおけるユーザーアイコンの表示ロジックを追加(`app/views/quiz_posts/_quiz_card.html.erb`)

## 動作確認方法
1. **トップページ**
   - [ ] トップページにアクセスし、ユーザーアイコンが正しく表示されることを確認
   - [ ] プロフィール画像がない場合にデフォルト画像が表示されることを確認
   
## スクリーンショット
![image](https://github.com/user-attachments/assets/b4af7d9e-75a1-4ebf-bbdc-71532ef7e45e)
