### PR TITLE
fix:言語別一覧ページにおけるプロフィール画像の動的反映

### DIFF
--- a/app/views/quizzes/_lg_card.html.erb
+++ b/app/views/quizzes/_lg_card.html.erb
@@ -16,7 +16,6 @@
           <% end %>
           <p class="text-sm"><%= quiz.user.name %></p>
         <% end %>
-        <%= link_to quiz.user.name, user_profile_path(quiz.user.id), class: "text-sm" %>
       </div>
       <p class="text-primary text-sm"><%= quiz.created_at.strftime('%Y/%m/%d') %></p>
     </div>


### PR DESCRIPTION
## 概要
- クイズカードにおけるユーザーのプロフィール画像を動的に表示する機能を追加

## 変更内容
- **修正**: クイズカードでのユーザーアイコン表示ロジックを追加 (`app/views/quizzes/_lg_card.html.erb`)
  - プロフィール画像が設定されている場合はその画像を表示し、設定されていない場合はデフォルト画像を表示

## 動作確認方法
1. **クイズカード表示**
   - [ ] クイズカードに、ユーザーのプロフィール画像が正しく表示されることを確認
   - [ ] プロフィール画像がない場合にデフォルト画像が表示されることを確認

## スクリーンショット（任意）
![image](https://github.com/user-attachments/assets/1e7541e1-0bc7-4477-9ce5-b0f7cb6b44d3)
