### PR TITLE
fix:名前が二つ入ってしまっているのを修正

### DIFF
--- a/app/views/quizzes/_lg_card.html.erb
+++ b/app/views/quizzes/_lg_card.html.erb
@@ -12,7 +12,6 @@
           <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary' %>
           <p class="text-sm"><%= quiz.user.name %></p>
         <% end %>
-        <%= link_to quiz.user.name, user_profile_path(quiz.user.id), class: "text-sm" %>
       </div>
       <p class="text-primary text-sm"><%= quiz.created_at.strftime('%Y/%m/%d') %></p>
     </div>


### PR DESCRIPTION
## 概要
` <%= link_to quiz.user.name, user_profile_path(quiz.user.id), class: "text-sm" %>`を削除して名前が二つ入ってしまっているのを修正しました

## 変更内容
- **修正**: 名前を一つにしました


## スクリーンショット（任意）
![image](https://github.com/user-attachments/assets/07302059-a76e-46d1-9461-1004f0859291)
