### PR TITLE
fix:quiz_posts/idからquestions/idへの遷移

### DIFF
--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -65,6 +65,6 @@
     </div>
   </div>
   <div class="flex justify-center items-center mt-2">
-    <button type="submit" class="text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6">クイズを始める</button>
+    <%= link_to 'クイズを始める', question_path(@quiz.questions.first), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
`link_to 'クイズを始める', question_path(@quiz.questions.first)`とすることで quiz_psots/idからquestions/idへの遷移を実現

## 変更内容
- **修正**: quiz_posts/idからquestions/idへの遷移