### PR TITLE
fix:クイズ詳細ページのタグを動的に変更できるようにした

### DIFF
--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -54,9 +54,14 @@
       </div>
       <div class="mt-4 flex items-center justify-between">
         <div>
-          <button class="btn btn-sm bg-html flex-1 text-sm text-white font-bold text-center text-nowrap mt-2">HTML</button>
-          <button class="btn btn-sm bg-css flex-1 text-sm text-white font-bold text-center text-nowrap mt-2 mr-4">CSS</button>
-          <span class="mt-2 text-sm">全 <%= @quiz.questions_count %> 門</span>
+          <div class="flex gap-4 items-center">
+            <% @quiz.tags.each do |tag| %>
+              <%= link_to tag_path(tag.id), class: "btn btn-sm text-sm text-white font-bold text-center text-nowrap mt-2 #{tag.data_color}" do %>
+                <%= tag.name %>
+              <% end %>
+            <% end %>
+             <span class="mt-2 text-sm">全 <%= @quiz.questions_count %> 問</span>
+          </div>
         </div>
         <div>
           <button class="bg-secondary hover:opacity-70 mt-2 px-4 py-1 rounded-lg shadow"><i class="fa-brands fa-x-twitter"></i>に共有する</button>
@@ -68,3 +73,5 @@
     <%= link_to 'クイズを始める', question_path(@quiz.questions.first), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
   </div>
 </div>
+
+


### PR DESCRIPTION
## 概要
- クイズ詳細画面でタグを動的に表示する機能を追加

## 変更内容
- **修正**: クイズ詳細画面 (`app/views/quiz_posts/show.html.erb`) でクイズに関連するタグを動的に表示
- **修正**: `QuizPostsController`の`show`アクションでクイズに関連するタグを取得

## 動作確認方法
1. **クイズ詳細表示**
   - [ ] クイズ詳細ページにアクセスし、関連するタグが正しく表示されることを確認
2. **タグリンク確認**
   - [ ] 各タグをクリックし、正しいタグページに遷移することを確認

## 備考
- タグの表示により、ユーザーが関連するクイズを見つけやすくなります。
- 本番環境での動作確認を推奨します。