### PR TITLE
全ページ動的タイトル化

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def page_title(title = "")
+    base_title = "Programming Question"
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
 end

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,7 +1,10 @@
-<div class="bg-white">
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, 'お問い合わせ') %>
+    </h1>
   </div>
+
 
   <% if @contact.errors.any? %>
     <ul>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-white min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
     <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <%= t('devise.registrations.new.title') %>
+      <% content_for(:title, '新規登録') %>
     </h1>
   </div>
 
@@ -68,3 +68,4 @@ function togglePasswordConfirmationVisibility() {
   passwordConfirmationField.type = passwordConfirmationField.type === "password" ? "text" : "password";
 }
 </script>
+

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-white min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
     <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <%= t('.title') %>
+      <% content_for(:title, 'ユーザーログイン') %>
     </h1>
   </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/privacy_policies/index.html.erb
+++ b/app/views/privacy_policies/index.html.erb
@@ -1,6 +1,9 @@
-<div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-  <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-</div>
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, 'プライバシーポリシー') %>
+    </h1>
+  </div>
 
 <div class="container mx-auto pt-3 px-12 py-24">
   <div class="mb-6">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, 'アカウント情報の更新') %>
+    </h1>
+  </div>
+
 <div class="bg-white">
   <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
     <h1 class="text-3xl font-bold text-accent text-center">ユーザープロフィール編集</h1>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+        <% content_for(:title, 'マイページ') %>
+    </h1>
+  </div>
+
 <div class="bg-gray-50 h-max m-5 p-10 flex flex-col ">
     <div class="flex flex-col justify-center items-center">
         <div class="bg-white w-[300px] p-5">

--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, "クイズの解説: #{@quiz.title}") %>
+    </h1>
+  </div>
+
 <div class="bg-secondary m-12 rounded-lg p-6 max-w-3xl mx-auto">
     <div class="bg-base-100 p-8 rounded-lg max-w-3xl mx-auto">
       <div class="flex items-center">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, "クイズに回答中: #{@quiz.title}") %>
+    </h1>
+  </div>
+
 <div class="bg-secondary m-12 rounded-lg p-6 max-w-3xl mx-auto">
   <div class="bg-base-100 p-8 rounded-lg max-w-3xl mx-auto">
     <div class="flex items-center">

--- a/app/views/quiz_posts/bookmarks.html.erb
+++ b/app/views/quiz_posts/bookmarks.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, 'ブックマーク一覧ページ') %>
+    </h1>
+  </div>
+
 <div class="flex flex-col mt-6 m-8">
   <div class="flex justify-center w-full mb-6">
     <h1 class="text-3xl font-bold text-accent text-center">ブックマークしたクイズ</h1>

--- a/app/views/quiz_posts/edit.html.erb
+++ b/app/views/quiz_posts/edit.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, 'クイズ編集') %>
+    </h1>
+  </div>
+
 <div class="bg-white">
   <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
     <h1 class="text-3xl font-bold text-accent text-center">クイズ編集</h1>

--- a/app/views/quiz_posts/index.html.erb
+++ b/app/views/quiz_posts/index.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, 'ようこそ') %>
+    </h1>
+  </div>
+
 <h1 class="text-primary text-center text-2xl bg-secondary p-6 mt-6">プログラミングで人生の可能性を広げよう！</h1>
 
 <div class="flex gap-1 p-6 mt-6">

--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, 'クイズ作成') %>
+    </h1>
+  </div>
+
 <%= form_with model: @quiz, url: quiz_posts_path, local: true do |form| %>
   <% if @quiz.errors.any? %>
     <div class="error-messages bg-red-100 text-red-700 border border-red-400 p-4 rounded mb-4">

--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, "#{@quiz.title}") %>
+    </h1>
+  </div>
+
 <div class="bg-secondary m-12 rounded-lg p-6 max-w-3xl mx-auto">
   <div class="bg-base-100 p-8 rounded-lg max-w-3xl mx-auto">
     <div class="flex justify-between items-center">

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,3 +1,10 @@
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, "クイズ一覧: #{@tag.name}") %>
+    </h1>
+  </div>
+
 <div class="flex flex-col mt-6 m-8">
   <div class="flex justify-center w-full ">
     <!-- プルダウンメニュー -->

--- a/app/views/terms_of_services/index.html.erb
+++ b/app/views/terms_of_services/index.html.erb
@@ -1,6 +1,9 @@
-<div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-  <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-</div>
+<div class="bg-white min-h-screen overflow-auto">
+  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <% content_for(:title, '利用規約') %>
+    </h1>
+  </div>
 
 <div class="container mx-auto pt-3 px-12 py-24">
 <p class="mb-6 ">本規約は、提供する「programing_question」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。</p>


### PR DESCRIPTION
## 概要
- 各ページに動的タイトルを実装し、ユーザー体験とSEOを向上させました。

## 変更内容
- **新規追加**: `page_title`メソッドを`app/helpers/application_helper.rb`に追加し、動的タイトルを生成。
- **修正**: 各ビューで`content_for`を使用してタイトルを設定。
どこを変えたかはFiles changedでご確認ください

## 動作確認方法
1. **各ページのタイトル確認**
   - [ ] 各ページにアクセスし、ブラウザのタブに正しいタイトルが表示されることを確認。
2. **SEO確認**
   - [ ] 検索エンジンでの表示を確認し、タイトルが適切に反映されていることを確認。

## 関連Issue
- #44 

## 備考- 動的タイトルの実装により、SEOの向上が期待されます。
- 各ページのタイトルが正しく表示されるか、特に注意して確認してください。

---