### PR TITLE
fix:共通ヘッダー 不要箇所コメントアウト

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,6 +3,7 @@
     <div class="flex items-center space-x-4">
       <%= image_tag 'logo.png', class: 'w-10 h-10' %>
         <%= link_to 'Programming Question', '/', class: 'text-primary font-bold text-lg font-frankfurter mr-10' %>
+          <!--（本リリース）検索機能
           <form class="flex items-center">
             <label for="simple-search" class="sr-only">Search</label>
             <div class="flex items-center gap-4">
@@ -21,6 +22,7 @@
               </button>
             </div>
           </form>
+          -->
     </div>
     <div class="flex items-center space-x-4 justify-end">
       <% if user_signed_in? %>
@@ -33,9 +35,11 @@
           <% end %>
         </div>
       <% end %>
+      <!--(本リリース)ブックマーク機能
         <%= link_to bookmarks_quiz_posts_path do %>
           <span class="material-icons md-36 text-primary">bookmark</span>
         <% end %>
+      -->
         <%= button_to destroy_user_session_path, method: :delete, data: { turbo_method: :delete } do %>
           <span class="material-icons md-36 text-primary">logout</span>
         <% end %>
@@ -43,7 +47,9 @@
         <div class="space-x-8">
           <%= link_to 'ログイン', new_user_session_path, class: 'text-primary font-bold text-base md:text-lg tracking-wide hover:opacity-70 transition duration-300' %>
           <%= link_to '新規登録', new_user_registration_path, class: 'text-primary font-bold text-base md:text-lg tracking-wide hover:opacity-70 transition duration-300' %>
+           <!--(本リリース)パスワードリセット機能
           <%= link_to 'パスワードリセット', new_user_password_path, class: 'text-primary font-bold text-base md:text-lg tracking-wide hover:opacity-70 transition duration-300' %>
+           -->
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
共通ヘッダーのコメントアウト化をしました。
- 検索フォーム
- ブックマークページへの遷移ボタン
- リセットパスワードページへの遷移リンク

## 変更内容
- **修正**: 共通ヘッダーのコメントアウト化（`app/views/shared/_header.html.erb`）

## 動作確認方法
1. **共通ヘッダー**
   - [X] `localhost:3000`を閲覧し確認しました。
 
## スクリーンショット
**【ログイン後】**
![スクリーンショット 2025-01-17 0 07 57](https://github.com/user-attachments/assets/64f739d9-3c93-4465-ab91-47a408c6c76a)
**【ログイン前】**
![スクリーンショット 2025-01-17 0 08 09](https://github.com/user-attachments/assets/04140b77-c789-46cd-8652-08c796c6ec15)


