### PR TITLE
fix:クイズ詳細ページ 不要箇所コメントアウト

### DIFF
--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -3,14 +3,16 @@
     <div class="flex justify-between items-center">
       <h1 class="text-3xl text-accent"><%= @quiz.title %></h1>
       <div class="flex text-primary">
+      <!--(本リリース)クイズ編集ページ
         <button>
           <span class="material-icons md-36">
             edit
           </span>
         </button>
+      -->
         <div class="flex text-primary space-x-4">
           <% if @quiz.author_user_id == current_user.id || current_user.admin? %>
-            <%= button_to @quiz, 
+            <%= button_to @quiz,
             method: :delete do %>
               <span class="material-icons md-36" >
                 delete
@@ -18,11 +20,13 @@
             <% end %>
           <% end %>
         </div>
+        <!--(本リリース)ブックマーク機能
         <button>
           <span class="material-icons md-36">
             bookmark_border
           </span>
         </button>
+        -->
       </div>
     </div>
     <div class="mt-4">
@@ -34,6 +38,7 @@
             <p class="text-sm"><%= @quiz.created_at.strftime("%Y-%m-%d") %></p>
           </div>
         </div>
+        <!--(本リリース)レビュー機能
         <div class="rating rating-md rating-half">
           <input type="radio" name="rating-10" class="rating-hidden" />
           <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
@@ -51,6 +56,7 @@
           <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
           <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
         </div>
+        -->
       </div>
       <div class="mt-4 flex items-center justify-between">
         <div>
@@ -73,5 +79,3 @@
     <%= link_to 'クイズを始める', question_path(@quiz.questions.first), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
   </div>
 </div>
-
-


### PR DESCRIPTION
## 概要
クイズ詳細ページのコメントアウト化をしました。
- クイズ編集ページへの遷移ボタン
- ブックマーク機能
- レビュー機能

## 変更内容
- **修正**: クイズ詳細ページのコメントアウト化（`app/views/quiz_posts/show.html.erb`）

## 動作確認方法
1. **クイズ詳細ページ**
   - [X] `http://localhost:3000/quiz_posts/1`を閲覧し確認しました。
 
## スクリーンショット
![スクリーンショット 2025-01-17 0 21 39](https://github.com/user-attachments/assets/4e1ccbe9-9476-4f50-b79e-39407694106f)



