### PR TITLE
fix:ユーザー情報更新ページ 不要箇所コメントアウト

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -36,10 +36,12 @@
             <%= f.text_field(:bio, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20") %>
           </div>
 
+          <!-- (本リリース)勉強している言語-分かりやすい文面を付け加える
           <div class="flex flex-col bg-white rounded p-6">
             <%= f.label(t("activerecord.attributes.profile.studying_languages"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
             <%= f.text_field(:studying_languages, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5") %>
           </div>
+          -->
 
           <div class="flex flex-col bg-white rounded p-6">
             <%= f.label(t("activerecord.attributes.profile.x_link"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
@@ -56,20 +58,20 @@
             <%= f.submit(t("activerecord.attributes.profile.update"), class: "btn btn-lg text-white text-center bg-accent text-3xl font-bold rounded-lg w-3/4 h-20") %>
           </div>
 
-          <!-- 退会ボタン -->
+          <!-- 退会ボタン
           <div class="flex justify-center mt-4">
             <%= f.submit(t("activerecord.attributes.profile.destroy"), class: "btn btn-lg text-white text-center bg-primary text-2xl font-bold rounded-lg w-3/4 h-16") %>
           </div>
-          
-          <!-- 注意文 -->
+
+
           <div class="text-right mt-2 w-3/4 mx-auto">
               <p class="text-sm text-gray-600">
                   ※退会すると全てのデータが削除されます。
               </p>
           </div>
+          -->
         </div>
       </div>
     </div>
-  <% end %> 
+  <% end %>
 </div>
-


### PR DESCRIPTION
## 概要
ユーザー情報更新ページのコメントアウト化をしました。
- 勉強している言語のフォーム欄
- 退会機能

## 変更内容
- **修正**: ユーザー情報更新ページのコメントアウト化（`app/views/profiles/edit.html.erb`）

## 動作確認方法
1. **ユーザー情報更新ページ**
   - [X] `localhost:3000/users/5/profile/edit`を閲覧し確認。

## スクリーンショット（任意）
![スクリーンショット 2025-01-17 9 23 13](https://github.com/user-attachments/assets/432a84dd-f5b3-41e2-a164-0c5c67c315a6)
