### PR TITLE
fix:プロフィールページ 不要部分コメントアウト

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,7 +27,9 @@
 
             <div class="bg-gray-50 text-sm mb-5 p-5 text-primary">
                 <p><%= @profile.bio %></p>
+                <!--(本リリース)勉強している言語-分かりやすい文面を付け加える
                 <p class="mt-5"><%= @profile[:studying_languages] %></p>
+                -->
             </div>
 
             <% if @user == current_user %>


### PR DESCRIPTION
## 概要
プロフィールページのコメントアウト化をしました。
- 勉強している言語の表示

## 変更内容
- **修正**: プロフィールページのコメントアウト化（`app/views/profiles/show.html.erb`）

## 動作確認方法
1. **ユーザー情報更新ページ**
   - [X] `localhost:3000/users/5/profile`を閲覧し確認。

## スクリーンショット（任意）
![スクリーンショット 2025-01-17 9 35 44](https://github.com/user-attachments/assets/f04b35a3-8774-4d39-9e52-31340c9bee96)

