### PR TITLE
fix:ユーザー新規登録後に強制的にプロフィール編集ページに飛ばす

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -6,4 +6,11 @@ class RegistrationsController < Devise::RegistrationsController
       end
     end
   end
+
+  protected
+
+  # ユーザー登録後のリダイレクト先を指定（親クラスにも同じ名前のメソッド名があり、ここでオーバーライドしている）
+  def after_sign_up_path_for(resource)
+    edit_user_profile_path(resource)
+  end
 end


### PR DESCRIPTION
## 概要
- ユーザーの新規登録後、プロフィール編集ページに自動遷移させるように改修

## 変更内容
- **修正**: ユーザーの新規登録後、プロフィール編集ページに自動遷移させる

## 動作確認方法
1. **ユーザー登録**
   - [x] 新規ユーザーを登録し、登録後に自動でプロフィール編集ページに遷移することを確認する

## 関連Issue

メソッドのオーバーライドを初めてやりました。楽しいです。