### PR TITLE
questionテーブルのpost_answersにdependent: :destroyを追加

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,7 @@ class Question < ApplicationRecord
   has_one_attached :question_image, dependent: :destroy
   has_one_attached :explanation_image, dependent: :destroy
   accepts_nested_attributes_for :choices, allow_destroy: true
+  has_many :past_answers, dependent: :destroy
 
   # 入力があればバリデーションを実行
   validates :question, presence: true, if: :required_question?


### PR DESCRIPTION
## 概要
- Questionモデルに`dependent: :destroy`を追加し、質問削除時に関連する回答履歴も削除されるように修正

## 変更内容
- **修正**: Questionモデルのアソシエーション設定を変更
  ```ruby
  class Question < ApplicationRecord
    has_many :past_answers, dependent: :destroy
  end
  ```

## 動作確認方法
1. **質問の削除**
   - [ ] 管理者画面から質問を削除し、正常に削除されることを確認
   - [ ] 関連する回答履歴も同時に削除されることを確認
2. **データの整合性**
   - [ ] 他の質問や回答履歴に影響がないことを確認
   - [ ] 外部キー制約違反のエラーが発生しないことを確認
3. **UI確認**
   - [ ] 管理者画面での削除操作が正常に完了すること
   - [ ] 適切なフラッシュメッセージが表示されること

## 備考
- 本番環境への適用前に、重要なデータのバックアップを推奨
- 必要に応じて、回答履歴を保持したい場合は`dependent: :nullify`への変更も検討可能