### PR TITLE
fix:ログインページ 不要部分コメントアウト

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -6,9 +6,9 @@
   <%= link_to t('.sign_up'), new_registration_path(resource_name), class: 'text-sm md:text-lg text-nowrap font-medium text-primary' %>
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t('.forgot_your_password'), new_password_path(resource_name), class: 'text-sm md:text-lg text-nowrap font-medium text-primary'%><br />
-<% end %>
+<%# if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%#= link_to t('.forgot_your_password'), new_password_path(resource_name), class: 'text-sm md:text-lg text-nowrap font-medium text-primary'%><br />
+<%# end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />


### PR DESCRIPTION
## 概要
ログインページのコメントアウト化をしました。
- リセットパスワードページへ遷移するリンク

## 変更内容
- **修正**: ログインページに表示されているリセットパスワードページへ遷移するリンクをコメントアウト化（`app/views/devise/shared/_links.html.erb`）

## 動作確認方法
1. **ユーザー情報更新ページ**
   - [X] `http://localhost:3000/users/sign_in`を閲覧し確認。

## スクリーンショット（任意）
![スクリーンショット 2025-01-18 16 00 51](https://github.com/user-attachments/assets/21b69258-fdd7-4cfd-af25-6ca773746a7e)


