### PR TITLE
dependent: :destroyをdependent: :nullifyに変更

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,7 +2,7 @@ class Question < ApplicationRecord
   belongs_to :quiz, counter_cache: true
   has_many :choices, dependent: :destroy
   has_one_attached :question_image, dependent: :destroy
-  has_one_attached :explanation_image, dependent: :destroy
+  has_one_attached :explanation_image, dependent: :nullify
   accepts_nested_attributes_for :choices, allow_destroy: true
   has_many :past_answers, dependent: :destroy
 


### PR DESCRIPTION
## 概要
- QuestionモデルのActiveStorageアタッチメント（question_image）の依存関係を`:destroy`から`:nullify`に変更

## 変更内容
- **修正**: `question_image`の`dependent`オプションを`:nullify`に変更
  - レコード削除時にファイルを完全に削除せず、関連付けのみを解除するように変更

## 動作確認方法
1. **質問の削除**
   - [ ] 画像付きの質問を削除した際に、関連するActiveStorageのAttachmentレコードの関連付けのみが解除される
   - [ ] 実際のファイルはストレージに残る

## 備考
- この変更により、質問を削除してもアップロードされた画像ファイルは保持されます
- 将来的に画像の再利用や復元が必要になった場合に対応できます