### PR TITLE
fix:新規クイズ作成ページのレイアウト修正

### DIFF
--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -26,20 +26,29 @@
       <div class="flex flex-col w-full mt-6 mb-6 mx-24">
         <div class="space-y-4">
           <div class="flex flex-col bg-white rounded p-6">
-            <%= form.label :title, t('.quizes_title'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
+            <div class="flex items-start">
+              <%= form.label :title, t('.quizes_title'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
+              <span class="text-accent ml-1">*</span>
+            </div>
             <%= form.text_field :title, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5" %>
           </div>
           <div class="bg-white rounded p-6 mb-6">
-            <label for="tag" class="block mb-2 text-lg font-medium text-primary"><%= t('.quizes_tags') %></label>
+            <div class="flex items-start">
+              <label for="tag" class="block mb-1 text-lg font-medium text-primary"><%= t('.quizes_tags') %></label>
+              <span class="text-accent ml-1">*</span>
+            </div>
+            <div class="text-sm text-gray-500 mb-2">
+              <%= t('.tags_annotation') %>
+            </div>
             <div class="flex justify-between space-x-2">
               <% @tags.each do |tag| %>
-                <label 
-                  class="tag-label btn flex-1 text-lg text-white text-bold text-center text-nowrap cursor-pointer <%= tag.data_color %>" 
+                <label
+                  class="tag-label btn flex-1 text-lg text-white text-bold text-center text-nowrap cursor-pointer <%= tag.data_color %>"
                   data-color="<%= tag.data_color %>">
-                  <input 
-                    type="checkbox" 
+                  <input
+                    type="checkbox"
                     name="quiz[tag_ids][]"
-                    value="<%= tag.id %>" 
+                    value="<%= tag.id %>"
                     class="tag-checkbox hidden"
                     <%= 'checked' if @quiz.tag_ids.include?(tag.id) %> >
                   <%= tag.name %>
@@ -49,59 +58,79 @@
           </div>
           <div class="divider"></div>
           <%= form.fields_for :questions, @current_question do |q_form| %>
-            <div class="flex flex-col bg-white rounded p-6">
-              <%= q_form.label :question, t('.question'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
-              <%= q_form.text_area :question, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20" %>
-            </div>
-            <div class="bg-white rounded p-6">
-              <div class="flex justify-between space-x-4 mb-6">
-                <%= q_form.fields_for :choices do |c_form| %>
-                  <div class="w-1/2">
-                    <%= c_form.label :choice1, t('.choices.1'), class: "block mb-2 text-lg font-medium text-primary" %>
-                    <%= c_form.text_area :choice1, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %> 
-                  </div>
-                  <div class="w-1/2">
-                    <%= c_form.label :choice2, t('.choices.2'), class: "block mb-2 text-lg font-medium text-primary" %>
-                    <%= c_form.text_area :choice2, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %>
-                  </div>
-                  <div class="w-1/2">
-                    <%= c_form.label :choice3, t('.choices.3'), class: "block mb-2 text-lg font-medium text-primary" %>
-                    <%= c_form.text_area :choice3, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %>
-                  </div>
-                  <div class="w-1/2">
-                    <%= c_form.label :choice4, t('.choices.4'), class: "block mb-2 text-lg font-medium text-primary" %>
-                    <%= c_form.text_area :choice4, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %>
-                  </div>
-                <% end %>
+            <div>
+              <div class="flex flex-col bg-white rounded p-6">
+                <div class="flex items-start">
+                  <%= q_form.label :question, t('.question'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
+                  <span class="text-accent ml-1">*</span>
+                </div>
+                <%= q_form.text_area :question, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20" %>
               </div>
-            </div>
-            <div class="bg-white rounded p-6">
-              <div class="flex flex-col justify-start">
-                <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary"><%= t('.answer') %></h2>
-                <%= q_form.select :correct_answer, 
-                  [[t('.choices.1'), 1], [t('.choices.2'), 2], [t('.choices.3'), 3], [t('.choices.4'), 4]], 
-                  { prompt: t('.choice_corrected_answer') }, 
-                  { class: "select select-bordered w-1/2" } %>
+              <div class="bg-white rounded">
+                <div class="flex justify-between space-x-4 p-6">
+                  <%= q_form.fields_for :choices do |c_form| %>
+                    <div class="w-1/2">
+                      <div class="flex items-start">
+                        <%= c_form.label :choice1, t('.choices.1'), class: "block mb-2 text-lg font-medium text-primary" %>
+                        <span class="text-accent ml-1">*</span>
+                      </div>
+                      <%= c_form.text_area :choice1, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %>
+                    </div>
+                    <div class="w-1/2">
+                      <div class="flex items-start">
+                        <%= c_form.label :choice2, t('.choices.2'), class: "block mb-2 text-lg font-medium text-primary" %>
+                        <span class="text-accent ml-1">*</span>
+                      </div>
+                      <%= c_form.text_area :choice2, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %>
+                    </div>
+                    <div class="w-1/2">
+                      <div class="flex items-start">
+                        <%= c_form.label :choice3, t('.choices.3'), class: "block mb-2 text-lg font-medium text-primary" %>
+                        <span class="text-accent ml-1">*</span>
+                      </div>
+                      <%= c_form.text_area :choice3, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %>
+                    </div>
+                    <div class="w-1/2">
+                      <div class="flex items-start">
+                        <%= c_form.label :choice4, t('.choices.4'), class: "block mb-2 text-lg font-medium text-primary" %>
+                        <span class="text-accent ml-1">*</span>
+                      </div>
+                      <%= c_form.text_area :choice4, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary p-2.5" %>
+                    </div>
+                  <% end %>
+                </div>
               </div>
-            </div>
-            <div class="flex flex-col bg-white rounded p-6">
-              <%= q_form.label :explanation, t('.explanation'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
-              <%= q_form.text_area :explanation, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20" %>
-            </div>
-            <div class="flex flex-col bg-white rounded p-6">
-              <%= q_form.label :answer_source, t('.answer_source'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
-              <%= q_form.text_field :answer_source, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5" %>
-            </div>
-            <div class="flex items-center bg-white rounded p-6 gap-8">
-              <%= q_form.label :question_image, t('.questions_image'), class: "block text-lg text-nowrap font-medium text-primary" %>
-              <%= q_form.file_field :question_image, class: "file-input file-input-bordered file-input-primary file-input-sm w-full" %>
-            </div>
-            <div class="flex items-center bg-white rounded p-6 gap-8">
-              <%= q_form.label :question_image, t('.explanation_image'), class: "block text-lg text-nowrap font-medium text-primary" %>
-              <%= q_form.file_field :explanation_image, class: "file-input file-input-bordered file-input-primary file-input-sm w-full" %>
+              <div class="bg-white rounded p-6">
+                <div class="flex flex-col justify-start">
+                  <div class="flex items-start">
+                    <h2 class="block mb-2 text-lg text-nowrap font-medium text-primary"><%= t('.answer') %></h2>
+                    <span class="text-accent ml-1">*</span>
+                  </div>
+                  <%= q_form.select :correct_answer,
+                    [[t('.choices.1'), 1], [t('.choices.2'), 2], [t('.choices.3'), 3], [t('.choices.4'), 4]],
+                    { prompt: t('.choice_corrected_answer') },
+                    { class: "select select-bordered w-1/2" } %>
+                </div>
+              </div>
+              <div class="flex flex-col bg-white rounded p-6">
+                <%= q_form.label :explanation, t('.explanation'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
+                <%= q_form.text_area :explanation, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20" %>
+              </div>
+              <div class="flex flex-col bg-white rounded p-6">
+                <%= q_form.label :answer_source, t('.answer_source'), class: "block mb-2 text-lg text-nowrap font-medium text-primary" %>
+                <%= q_form.text_field :answer_source, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5" %>
+              </div>
+              <div class="flex items-center bg-white rounded p-6 gap-8">
+                <%= q_form.label :question_image, t('.questions_image'), class: "block text-lg text-nowrap font-medium text-primary" %>
+                <%= q_form.file_field :question_image, class: "file-input file-input-bordered file-input-primary file-input-sm w-full" %>
+              </div>
+              <div class="flex items-center bg-white rounded p-6 gap-8 mb-12">
+                <%= q_form.label :question_image, t('.explanation_image'), class: "block text-lg text-nowrap font-medium text-primary" %>
+                <%= q_form.file_field :explanation_image, class: "file-input file-input-bordered file-input-primary file-input-sm w-full" %>
+              </div>
             </div>
           <% end %>
-          <!-- ページネーション 
+          <!-- ページネーション
           <div class="flex justify-center gap-2">
             <div class="join mt-6">
               <button class="join-item btn btn-sm bg-primary text-base-100">1</button>

--- a/config/locales/quiz.ja.yml
+++ b/config/locales/quiz.ja.yml
@@ -35,9 +35,10 @@ ja:
     new:
       errors_blank: "入力内容を確認してください"
       title: "新規クイズ作成"
-      create_limit: "10問作成できます"
+      create_limit: "1問~10問作成できます"
       quizes_title: "クイズ集タイトル"
       quizes_tags: "クイズ集タグ"
+      tags_annotation: "※ エラータグのみ複数選択が可能です。他のタグを選択後、エラータグを選択してください。"
       question: "問題文"
       choices:
         1: "選択肢1"


### PR DESCRIPTION
## 概要
新規クイズ作成ページのレイアウト修正を行いました。
- 新規クイズ作成フォームに、必須項目を示すための*を追加
- 各問題の間に空白を追加
- クイズ集タグに注釈を追加
（※ エラータグのみ複数選択が可能です。他のタグを選択後、エラータグを選択してください。）
- クイズ問題数に関する文言を変更
（10問作成できます→1問~10問作成できます）
- 上記に関する日本語化の追加・変更

## 変更内容
- **追加・修正**: （`app/views/quiz_posts/new.html.erb`・`config/locales/quiz.ja.yml`）

## 動作確認方法
1. **新規クイズ作成ページ**
   - [X] `localhost:3000/quiz_posts/new`を閲覧し確認。


## スクリーンショット（任意）

![スクリーンショット 2025-01-19 14 21 45](https://github.com/user-attachments/assets/58dd5a2a-256e-41c6-8283-e43b54ee7745)
![スクリーンショット 2025-01-19 14 21 58](https://github.com/user-attachments/assets/6a53aeb2-2ba1-4368-95cb-d0ac051bb821)

