### PR TITLE
fix:新規クイズ作成ページの i18nの文言を修正

### DIFF
--- a/config/locales/quiz.ja.yml
+++ b/config/locales/quiz.ja.yml
@@ -50,6 +50,6 @@ ja:
       choice_corrected_answer: "正解の選択肢を選ぶ"
       explanation: "解説文"
       answer_source: "クイズ作成時の参考資料（URL）"
-      questions_image: "問題画像 画像アップロード"
+      questions_image: "問題用 画像アップロード"
       explanation_image: "回答用 画像アップロード"
       submit: "登録する"


### PR DESCRIPTION
## 概要
- 新規クイズ作成ページの i18nの文言を修正

## 変更内容
- **修正**: 新規クイズ作成ページの i18nの文言を修正(`config/locales/quiz.ja.yml`)

## 動作確認方法
1. **新規クイズ作成ページ**
   - [ ] 「問題用 画像アップロード」と表示されている

## 関連Issue

## スクリーンショット
新規クイズ作成ページ
<img width="938" alt="スクリーンショット 2025-01-20 14 13 55" src="https://github.com/user-attachments/assets/4954c5e1-5dc7-4160-a103-4a0dbe9824c3" />