### PR TITLE
Xリンクのバグを修正

### DIFF
--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -132,7 +132,7 @@
             <% end %>
           </div>
           <div class="flex justify-center items-center mt-4 space-x-4">
-            <% twitter_share_url = "https://twitter.com/share?url=#{CGI.escape(quiz_url(@quiz))}" %>
+            <% twitter_share_url = "https://twitter.com/share?url=#{CGI.escape(quiz_post_url(@quiz))}" %>
             <%= link_to twitter_share_url, target: "_blank", data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア" do %>
               <button class="bg-secondary hover:opacity-70 rounded-lg text-lg px-5 py-2.5 flex items-center justify-center gap-2 w-64">
                 <i class="fa-brands fa-x-twitter"></i>に共有する


### PR DESCRIPTION
## 概要
- クイズを解き終わった後のX共有ボタンで生成されるリンクを正しいものに直しました。

## 変更内容
- **修正**: app/views/questions/result.html.erbを修正

## 動作確認方法
1. **X共有ボタンを押す**
   - [x] クイズを解き終わった後のX共有ボタンで生成されるリンクから、クイズ詳細画面に遷移できることを確認する。

## スクリーンショット（任意）
![image](https://github.com/user-attachments/assets/3d990028-7ad1-41d5-b234-ea0a86d1c772)
