### PR TITLE
fix/クイズ詳細ページのプロフィール画像をクリックするとプロフィールページへ遷移する

### DIFF
--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -39,7 +39,9 @@
     <div class="mt-4">
       <div class="flex justify-between items-center">
         <div class="flex items-center space-x-2">
-          <%= image_tag @quiz.user.profile&.user_icon&.attached? ? @quiz.user.profile.user_icon : 'profile_sample.png', class: 'w-8 h-8 rounded-full object-cover border border-primary' %>
+          <%= link_to user_profile_path(@quiz.user.id) do %>
+            <%= image_tag @quiz.user.profile&.user_icon&.attached? ? @quiz.user.profile.user_icon : 'profile_sample.png', class: 'w-8 h-8 rounded-full object-cover border border-primary' %>
+          <% end %>
           <div class="mt-4">
             <p class="text-primary"><%= @quiz.user.name %></p>
             <p class="text-sm"><%= @quiz.created_at.strftime("%Y-%m-%d") %></p>


### PR DESCRIPTION
## 概要
- クイズ詳細ページでプロフィール画像をクリックすると、プロフィールページに遷移する機能を追加

## 変更内容
- **新規追加**: プロフィール画像クリック時の遷移機能 (`app/views/quiz_posts/show.html.erb`)
- **修正**: プロフィール画像のリンク設定を追加
- **リファクタリング**: コードの可読性向上のため、関連する部分を整理

## 動作確認方法
1. **プロフィール画像クリック**
   - [ ] クイズ詳細ページでプロフィール画像をクリックし、プロフィールページに遷移することを確認
2. **リンク確認**
   - [ ] プロフィール画像が正しいURLにリンクされていることを確認
3. **その他**
   - [ ] ページ遷移後、プロフィール情報が正しく表示されることを確認
