### PR TITLE
Fix 長いURLを切り捨て表示

### DIFF
--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -76,7 +76,7 @@
           </p>
           <h2 class="mt-12 text-accent">クイズ作成時の参考資料（URL）</h2>
           <p class="text-sm link">
-            <%= link_to @question.answer_source, @question.answer_source %>
+            <%= link_to @question.answer_source.truncate(50), @question.answer_source %>
           </p>
           <div>
             <% if @question.question_image.attached? %>


### PR DESCRIPTION
## 概要
クイズ解答後、長いURLを切り捨て表示します。

## 変更内容
<!-- 具体的な変更内容や追加した機能について箇条書きで記載 -->
- **修正**: 概要の通り

## 動作確認方法
<!-- どのように動作確認を行ったか、具体的な手順を記載 -->
1. **長いURLの場合**
   - [ ] [![Image from Gyazo](https://i.gyazo.com/fa985d09e6e36ce717c8a4c30f15fe2d.png)](https://gyazo.com/fa985d09e6e36ce717c8a4c30f15fe2d)
2. **短いURLの場合**
   - [ ] [![Image from Gyazo](https://i.gyazo.com/47aab10fb4137262f7e6ca803217dfcb.png)](https://gyazo.com/47aab10fb4137262f7e6ca803217dfcb)


## 関連Issue


## スクリーンショット（任意）


## 参考資料


## 備考
<!-- その他、レビュアーに伝えたいことがあれば記載 -->
- 今回の修正により影響がありそうな箇所: ユーザー登録・ログイン
- 本番環境に表示されるかの懸念材料がある部分等