### PR TITLE
fix/クイズ詳細ページの名前とTOP ページのプロフィール画像をlinkにしました

### DIFF
--- a/app/views/quiz_posts/_quiz_card.html.erb
+++ b/app/views/quiz_posts/_quiz_card.html.erb
@@ -4,10 +4,12 @@
   </p>
  <!-- 作成者情報 -->
   <div class="flex gap-1 items-center">
-    <% if quiz.user&.profile&.user_icon&.attached? %>
-      <%= image_tag quiz.user.profile.user_icon, class: 'w-6 h-6 rounded-full object-cover border border-primary border--300' %>
-    <% else %>
-      <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary border--300' %>
+    <%= link_to user_profile_path(quiz.user.id), class: "flex items-center gap-2" do %>
+      <% if quiz.user&.profile&.user_icon&.attached? %>
+        <%= image_tag quiz.user.profile.user_icon, class: 'w-6 h-6 rounded-full object-cover border border-primary border--300' %>
+      <% else %>
+        <%= image_tag 'profile_sample.png', class: 'w-6 h-6 rounded-full object-cover border border-primary border--300' %>
+      <% end %>
     <% end %>
     <%= link_to user_profile_path(quiz.user.id), class: "flex items-center gap-2" do %>
       <p><%= quiz.user&.name || "作者不明" %></p>

--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -43,7 +43,9 @@
             <%= image_tag @quiz.user.profile&.user_icon&.attached? ? @quiz.user.profile.user_icon : 'profile_sample.png', class: 'w-8 h-8 rounded-full object-cover border border-primary' %>
           <% end %>
           <div class="mt-4">
-            <p class="text-primary"><%= @quiz.user.name %></p>
+            <%= link_to user_profile_path(@quiz.user.id) do %>
+              <p class="text-primary"><%= @quiz.user.name %></p>
+            <% end %>
             <p class="text-sm"><%= @quiz.created_at.strftime("%Y-%m-%d") %></p>
           </div>
         </div>


### PR DESCRIPTION
## 概要
クイズ詳細ページの名前とTOP ページのプロフィール画像をlinkにしました

## 変更内容
クイズ詳細ページの名前とTOP ページのプロフィール画像をlinkにしました
