### PR TITLE
fix:別のクイズに遷移、問題途中にトップに戻るボタンが出るバグの修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -7,6 +7,7 @@ class QuestionsController < ApplicationController
   def show
     begin
       @question = Question.find(params[:id])
+      puts params[:id]
       @quiz = @question.quiz
       @choices = Choice.where(question_id: @question.id)
       choices_adjust(@choices)
@@ -57,7 +58,7 @@ end
       redirect_to root_path and return
     end
 
-    @next_question = Question.where("id > ? AND quiz_id = ?", @question.id, @question.quiz_id).first
+    @next_question = Question.where("id > ? AND quiz_id = ?", @question.id, @quiz.id).order(:id).first
     @has_next_question = @next_question.present?
 
     # メタタグの設定

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -118,7 +118,9 @@
   
       if (!document.getElementById("explanation-link")) {
         const explanationLink = document.createElement("a");
-        explanationLink.href = `<%= result_question_path(@question) %>`;
+        const currentUrl = window.location.href;
+
+        explanationLink.href = `${currentUrl}/result`;
         explanationLink.className = "text-accent text-lg hover:opacity-70";
         explanationLink.textContent = "解説ページを見る";
         explanationLink.id = "explanation-link"; 

--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -88,6 +88,6 @@
     </div>
   </div>
   <div class="flex justify-center items-center mt-2">
-    <%= link_to 'クイズを始める', question_path(@quiz.questions.first), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
+    <%= link_to 'クイズを始める', question_path(@quiz.questions.order(:id).first), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
<!-- このプルリクエストで何を実装・修正したのか具体的に記載してください -->
- 別のクイズに遷移してしまうバグの修正
- 問題途中にトップに戻るボタンが出るバグの修正

## 変更内容

- **新規追加**: 
- **修正**: 
- **削除**: 
- **リファクタリング**: 

## 動作確認方法

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->


## スクリーンショット（任意）


## 参考資料


## 備考
`question_path(@quiz.questions.first)`から必ず一番若いidに遷移するように`question_path(@quiz.questions.order(:id).first)`へ変更しています。

`result_question_path(@question)`で別の問題のリザルトへ遷移する場合があったので`const currentUrl = window.location.href;`から現在のURL＋/resultに強制的になるように
```
const currentUrl = window.location.href;
explanationLink.href = `${currentUrl}/result`;
```
へ変更