### PR TITLE
fix:クイズの正解・不正解でduckの画像を出し分け

### DIFF
--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -19,13 +19,13 @@
       </div>
 
       <div class="flex gap-8 justify-center items-center mt-12">
-        <%= image_tag 'duck_correct.png' , class: 'w-16 h-16' %>
+        <%= image_tag @past_answer.answer_result ? 'duck_correct.png' : 'duck_incorrect.png', class: 'w-16 h-16' %>
           <p class="text-2xl">
             <% if @past_answer.answer_result %>
-              <i class="fa-regular fa-circle text-md text-red-500"></i>正解
-              <% else %>
-                <i class="fa-solid fa-x text-md text-blue-500"></i> 不正解
-                <% end %>
+              <i class="fa-regular fa-circle text-md text-red-500"></i> 正解
+            <% else %>
+              <i class="fa-solid fa-x text-md text-blue-500"></i> 不正解
+            <% end %>
           </p>
       </div>
       <h2 class="mt-12 text-accent">問題</h2>


### PR DESCRIPTION
## 概要
- クイズの正解・不正解でduckの画像を出し分け

## 変更内容
- **修正**: クイズの正解・不正解でduckの画像を出し分け (`app/views/questions/result.html.erb`)

## 動作確認方法
1. **クイズ解説画面**
   - [ ] 正解・不正解でduckの画像が出し分けられている

## 関連Issue

## スクリーンショット
クイズ解説ページ
| 正解 | 不正解 |
| ---- | ---- |
|<img width="794" alt="スクリーンショット 2025-01-22 12 38 22" src="https://github.com/user-attachments/assets/20b65f19-5310-4088-bd4d-737c211c8fb4" /> | <img width="804" alt="スクリーンショット 2025-01-22 12 38 41" src="https://github.com/user-attachments/assets/dedc2af6-3fef-4117-8557-a2839fa4683b" /> |
