### PR TITLE
fix/クイズを解くとファイルがダウンロードされる問題

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -27,7 +27,7 @@ class QuestionsController < ApplicationController
   user_answer = params[:answer]
   correct_answer = @question.correct_answer
   is_correct = (user_answer.to_s == correct_answer.to_s)
-  redirect_to question_result_path(question_id: @question.id, is_correct: is_correct)
+  redirect_to result_question_path(question_id: @question.id, is_correct: is_correct)
 
   past_answer = PastAnswer.find_or_initialize_by(
     question_id: @question.id,

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -27,6 +27,7 @@ class QuestionsController < ApplicationController
   user_answer = params[:answer]
   correct_answer = @question.correct_answer
   is_correct = (user_answer.to_s == correct_answer.to_s)
+  redirect_to question_result_path(question_id: @question.id, is_correct: is_correct)
 
   past_answer = PastAnswer.find_or_initialize_by(
     question_id: @question.id,

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -122,7 +122,7 @@
 
         explanationLink.href = `${currentUrl}/result`;
         explanationLink.className = "text-accent text-lg hover:opacity-70";
-        explanationLink.textContent = "解説ページを見る";
+        // explanationLink.textContent = "解説ページを見る";
         explanationLink.id = "explanation-link"; 
         resultContainer.appendChild(explanationLink);
       }


### PR DESCRIPTION
## 概要
クイズを解くとファイルがダウンロードされる問題を、redirect先を`redirect_to question_result_path(question_id: @question.id, is_correct: is_correct)`にすることで一時的に解決しました（現状は解説ページを見るが、意味をなさないため、コメントアウトしました）
## 変更内容
- **修正**:回答するを押したときのredirect先に`question_result_path(question_id: @question.id, is_correct: is_correct)`を設定
- 解説ページを見るを一時的にコメントアウト

