### PR TITLE
@profile_formが余計だったため削除

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,7 +14,6 @@ class ProfilesController < ApplicationController
 
   def edit
     user_inspections(@user)
-    @profile_form = UserProfileForm.new(@user, @user.profile || @user.build_profile)
   end
 
   def update

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,7 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!, only: [ :edit, :update ]
+  before_action :set_user
   before_action :set_user_profile_form, only: [ :edit, :update ]
-  before_action :set_user, only: [ :show ]
 
   def show
     @profile = @user.profile
@@ -33,7 +33,6 @@ class ProfilesController < ApplicationController
   end
 
   def set_user_profile_form
-    @user = set_user
     @profile = @user.profile
     @user_profile_form = UserProfileForm.new(@user, @profile)
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,7 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!, only: [ :edit, :update ]
   before_action :set_user_profile_form, only: [ :edit, :update ]
-  before_action :set_user
+  before_action :set_user, only: [ :show ]
 
   def show
     @profile = @user.profile
@@ -33,7 +33,7 @@ class ProfilesController < ApplicationController
   end
 
   def set_user_profile_form
-    @user = User.find(params[:user_id])
+    @user = set_user
     @profile = @user.profile
     @user_profile_form = UserProfileForm.new(@user, @profile)
   end

--- a/app/forms/user_profile_form.rb
+++ b/app/forms/user_profile_form.rb
@@ -36,6 +36,7 @@ class UserProfileForm
     self.github_link = @profile.github_link || ""
   end
 
+  # データを保存
   def save(user_profile_form_params)
     return set_error_and_return_false("Validation faild") unless valid?
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -10,17 +10,15 @@
     <h1 class="text-3xl font-bold text-accent text-center">ユーザープロフィール編集</h1>
   </div>
 
-  <%= form_with(model: @user_profile_form, url: user_profile_path, local: true, data: {turbo: false}, method: :patch, multipart: true)  do |f| %>
-      <% if @user.errors.any? %>
+  <%= form_with(model: @user_profile_form,
+                url: user_profile_path,
+                local: true,
+                data: {turbo: false},
+                method: :patch,
+                multipart: true)  do |f| %>
+      <% if @user_profile_form.errors.any? %>
         <ul>
-          <% @user.errors.full_messages.each do |error| %>
-            <li><%= error %></li>
-          <% end %>
-        </ul>
-      <% end %>
-      <% if @profile_form.errors.any? %>
-        <ul>
-          <% @profile_form.errors.full_messages.each do |error| %>
+          <% @user_profile_form.errors.full_messages.each do |error| %>
             <li><%= error %></li>
           <% end %>
         </ul>


### PR DESCRIPTION
## 概要
- @profile_formが必要なかったため、余計なコードを削除しました。

## 変更内容
- **削除**: 未使用のインスタンスを削除

## 動作確認方法
1. **ローカルで確認**
   - [x] 既存ユーザーでログインし、自身のプロフィール編集画面に遷移してエラーが出ていないことを確認

## スクリーンショット（任意）
![localhost_3000_users_1_profile_edit(PC(1280px))](https://github.com/user-attachments/assets/48eeb29a-0c5c-4c0a-a898-6b50b9301664)