### PR TITLE
fix:プロフィールページ-SNSリンクアイコン表示を修正

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -28,8 +28,11 @@
             </div>
 
             <div class="flex items-center justify-center text-[25px] space-x-8 my-5">
-                <%= link_to "", @profile[:x_link], class: "fa-brands fa-x-twitter" %>
-                <%= link_to "", @profile[:github_link], class: "fa-brands fa-github" %>
+                <%= link_to url_for(@profile[:x_link]), target: "_blank", rel: "noopener noreferrer", class: "fa-brands fa-x-twitter #{'opacity-30 pointer-events-none' if @profile[:x_link].blank?}" do %>
+                <% end %>
+
+                <%= link_to url_for(@profile[:github_link]), target: "_blank", rel: "noopener noreferrer", class: "fa-brands fa-github #{'opacity-30 pointer-events-none' if @profile[:github_link].blank?}" do %>
+                <% end %>
             </div>
 
             <div class="bg-gray-50 text-sm mb-5 p-5 text-primary">


### PR DESCRIPTION
## 概要
- プロフィールページのSNSリンクnill時のアイコン表示を修正
- プロフィールページのSNSリンクに`target="_blank"`クラスを追加

## 変更内容
- **修正**:SNSリンクがnillの場合、`opacity-30`と`pointer-events-none` を付与・`target="_blank"`クラスの追加(`app/views/profiles/show.html.erb`)

## 動作確認方法

1. **プロフィールページ-SNSリンクnill時のアイコン表示**
![スクリーンショット 2025-02-07 12 59 21](https://github.com/user-attachments/assets/1c008a0b-dcc8-4b33-bcf4-f8648f2f4162)
![スクリーンショット 2025-02-07 12 59 31](https://github.com/user-attachments/assets/4442a9a6-19b7-4b74-ba70-9e6f5e3c38d6)


2. **プロフィールページ-`target="_blank"`クラスの追加**
[![Image from Gyazo](https://i.gyazo.com/5f9e3889e09f5b439d248c19746c053b.gif)](https://gyazo.com/5f9e3889e09f5b439d248c19746c053b)

## 関連Issue
- #471

