### PR TITLE
クイズ詳細ページのレスポンシブ対応

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
 
   <body class="font-mplus">
     <%= render 'shared/header' %>
-    <main class="pt-20">
+    <main class="pt-12 md:pt-20">
       <%= render 'devise/shared/flash_messages' %>
       <%= yield %>
     </main>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -17,6 +17,6 @@
   "display": "standalone",
   "scope": "/",
   "description": "Myapp.",
-  "theme_color": "red",
+  "theme_color": "f3f4f6",
   "background_color": "red"
 }

--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -5,95 +5,93 @@
     </h1>
   </div>
 
-<div class="bg-secondary m-12 rounded-lg p-6 max-w-3xl mx-auto">
-  <div class="bg-base-100 p-8 rounded-lg max-w-3xl mx-auto">
-    <div class="flex justify-between items-center">
-      <h1 class="text-3xl text-accent"><%= @quiz.title %></h1>
-      <div class="flex text-primary">
-      <!--(本リリース)クイズ編集ページ
-        <button>
-          <span class="material-icons md-36">
-            edit
-          </span>
-        </button>
-      -->
-        <div class="flex text-primary space-x-4">
-          <% if @quiz.author_user_id == current_user.id || current_user.admin? %>
-            <%= button_to @quiz,
-            method: :delete do %>
-              <span class="material-icons md-36" >
-                delete
-              </span>
-            <% end %>
-          <% end %>
-        </div>
-        <!--(本リリース)ブックマーク機能
-        <button>
-          <span class="material-icons md-36">
-            bookmark_border
-          </span>
-        </button>
-        -->
-      </div>
-    </div>
-    <div class="mt-4">
+<div class="flex justify-center m-6 md:m-12">
+  <div class="bg-secondary rounded-lg p-6 mx-auto max-w-3xl w-full">
+    <div class="bg-base-100 p-4 md:p-8 rounded-lg space-y-6">
       <div class="flex justify-between items-center">
-        <div class="flex items-center space-x-2">
-          <%= link_to user_profile_path(@quiz.user.id) do %>
-            <%= image_tag @quiz.user.profile&.user_icon&.attached? ? @quiz.user.profile.user_icon : 'profile_sample.png', class: 'w-8 h-8 rounded-full object-cover border border-primary' %>
-          <% end %>
-          <div class="mt-4">
-            <%= link_to user_profile_path(@quiz.user.id) do %>
-              <p class="text-primary"><%= @quiz.user.name %></p>
-            <% end %>
-            <p class="text-sm"><%= @quiz.created_at.strftime("%Y-%m-%d") %></p>
-          </div>
-        </div>
-        <!--(本リリース)レビュー機能
-        <div class="rating rating-md rating-half">
-          <input type="radio" name="rating-10" class="rating-hidden" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
-          <input
-            type="radio"
-            name="rating-10"
-            class="mask mask-star mask-half-1 bg-primary"
-            checked="checked" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
-          <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
-        </div>
+        <h1 class="text-lg md:text-3xl text-accent"><%= @quiz.title %></h1>
+        <div class="flex text-primary">
+        <!--(本リリース)クイズ編集ページ
+          <button>
+            <span class="material-icons md-36">
+              edit
+            </span>
+          </button>
         -->
-      </div>
-      <div class="mt-4 flex items-center justify-between">
-        <div>
-          <div class="flex gap-4 items-center">
-            <% @quiz.tags.each do |tag| %>
-              <%= link_to tag_path(tag.id), class: "btn btn-sm text-sm text-white font-bold text-center text-nowrap mt-2 #{tag.data_color}" do %>
-                <%= tag.name %>
+          <div class="flex text-primary space-x-4">
+            <% if @quiz.author_user_id == current_user.id || current_user.admin? %>
+              <%= button_to @quiz,
+              method: :delete do %>
+                <span class="material-icons md-36" >
+                  delete
+                </span>
               <% end %>
             <% end %>
-             <span class="mt-2 text-sm">全 <%= @quiz.questions_count %> 問</span>
           </div>
+          <!--(本リリース)ブックマーク機能
+          <button>
+            <span class="material-icons md-36">
+              bookmark_border
+            </span>
+          </button>
+          -->
         </div>
-        <div>
+      </div>
+      <div class="flex items-center gap-2">
+        <%= link_to user_profile_path(@quiz.user.id) do %>
+          <%= image_tag @quiz.user.profile&.user_icon&.attached? ? @quiz.user.profile.user_icon : 'profile_sample.png', class: 'w-8 h-8 rounded-full object-cover border border-primary' %>
+        <% end %>
+        <div class="flex md:flex-col flex-row justify-between md:flex-grow-0 flex-grow md:mt-4 items-center md:items-start">
+          <%= link_to user_profile_path(@quiz.user.id) do %>
+            <p class="text-primary text-base"><%= @quiz.user.name %></p>
+          <% end %>
+          <div>
+            <p class="text-sm"><%= @quiz.created_at.strftime("%Y-%m-%d") %></p>
+          </div>
+          <!--(本リリース)レビュー機能
+          <div class="rating rating-md rating-half">
+            <input type="radio" name="rating-10" class="rating-hidden" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
+            <input
+              type="radio"
+              name="rating-10"
+              class="mask mask-star mask-half-1 bg-primary"
+              checked="checked" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-1 bg-primary" />
+            <input type="radio" name="rating-10" class="mask mask-star mask-half-2 bg-primary" />
+          </div>
+          -->
+        </div>
+      </div>
+      <div class="flex flex-col md:flex-row md:justify-between">
+        <div class="flex items-center gap-4">
+          <% @quiz.tags.each do |tag| %>
+            <%= link_to tag_path(tag.id), class: "btn btn-sm text-sm text-white font-bold text-center text-nowrap mt-2 #{tag.data_color}" do %>
+              <%= tag.name %>
+            <% end %>
+          <% end %>
+          <span class="mt-2 text-sm">全 <%= @quiz.questions_count %> 問</span>
+        </div>
+        <div class="mt-8 md:mt-0">
           <!-- 設定したメタタグをリダイレクトされる前に呼び出す -->
           <% prepare_meta_tags @quiz %> 
           <% twitter_share_url = "https://twitter.com/share?url= #{CGI.escape(quiz_post_url(@quiz))}" %>
           <%= link_to twitter_share_url, target: "_blank", data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア" do %>
-            <button class="bg-secondary hover:opacity-70 mt-2 px-4 py-1 rounded-lg shadow">
+            <button class="bg-secondary hover:opacity-70 px-4 py-1 rounded-lg shadow">
               <i class="fa-brands fa-x-twitter"></i>に共有する
             </button> 
           <% end %>
         </div>
       </div>
     </div>
-  </div>
-  <div class="flex justify-center items-center mt-2">
-    <%= link_to 'クイズを始める', question_path(@quiz.questions.order(:id).first), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
+    <div class="flex justify-center items-center mt-2 mb-2">
+      <%= link_to 'クイズを始める', question_path(@quiz.questions.order(:id).first), class: 'text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center mt-6' %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,9 +1,9 @@
 <div class="bg-secondary w-full">
   <div class="md:ml-5 flex flex-col md:flex-row md:justify-between md:items-center p-4">
     <div class="flex flex-col md:flex-row md:space-x-4 space-y-4 md:space-y-0">
-      <%= link_to 'お問い合わせ', new_contacts_path, class: 'text-sm md:text-base text-primary text-nowrap font-bold' %>
-      <%= link_to '利用規約', terms_of_services_path, class: 'text-sm md:text-base text-primary text-nowrap font-bold' %>
-      <%= link_to 'プライバシーポリシー', privacy_policies_path, class: 'text-sm md:text-base text-primary text-nowrap font-bold' %>
+      <%= link_to 'お問い合わせ', new_contacts_path, class: 'text-sm md:text-base text-primary text-nowrap md:font-bold' %>
+      <%= link_to '利用規約', terms_of_services_path, class: 'text-sm md:text-base text-primary text-nowrap md:font-bold' %>
+      <%= link_to 'プライバシーポリシー', privacy_policies_path, class: 'text-sm md:text-base text-primary text-nowrap md:font-bold' %>
     </div>
     <div class="flex items-center justify-between md:space-x-2 md:mr-5 mt-6 md:mt-0">
       <p class="text-xs md:text-sm text-primary md:font-bold">© 2024 Programming Question. All rights reserved.</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -58,15 +58,15 @@
           </div>
           <ul tabindex="0" class="dropdown-content menu bg-white rounded-box p-2 shadow space-y-2">
             <li>
-              <%= link_to 'プロフィール', user_profile_path(current_user.id), class: "text-primary font-bold text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap" %>
+              <%= link_to 'プロフィール', user_profile_path(current_user.id), class: "text-primary text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap" %>
             </li>
             <!--(本リリース)ブックマーク機能
             <li>
-              <%= link_to 'ブックマーク', bookmarks_quiz_posts_path, class: 'text-primary font-bold text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
+              <%= link_to 'ブックマーク', bookmarks_quiz_posts_path, class: 'text-primary text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
             </li>
             -->
             <li>
-              <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'text-primary font-bold text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
+              <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'text-primary text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## 概要
- クイズ詳細ページのレスポンシブ対応

## 変更内容
- **追加: クイズ詳細ページのレスポンシブ対応(`app/views/quiz_posts/show.html.erb`)
- **追加: コンテンツ上部の余白のレスポンシブ対応(`app/views/layouts/application.html.erb`)
- **変更: 画面幅が狭い時の文字の太さを変更(`app/views/shared/_header.html.erb`)(`app/views/shared/_footer.html.erb`)
- **追加: スマートフォンで開いた時の画面上部の色を設定(`app/views/pwa/manifest.json.erb`)

## 動作確認方法
1. **クイズ詳細ページ**
   - [ ] レスポンシブ対応がされている
2. **全ページ**
   - [ ] コンテンツ上部（ヘッダー下）の余白のレスポンシブ対応がされている
3. **ヘッダーのドロップダウン、フッター**
   - [ ] 画面幅が小さい時は太字で表示されていない
4. **その他**
   - [ ] スマートフォンで開いた時、画面上部（ヘッダー上）がヘッダーと同じ色になっている

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
- #81 

## スクリーンショット
**クイズ詳細ページ**
| PC | スマホ |
| ---- | ---- |
|  <img width="1498" alt="スクリーンショット 2025-02-10 21 52 57" src="https://github.com/user-attachments/assets/cde1f598-8b3e-44ec-9370-22943d93e692" /> |  ![localhost_3000_quiz_posts_4(iPhone SE)](https://github.com/user-attachments/assets/fa64bb88-8514-4745-9cec-acf2d697fcc2)  | 

| コンテンツ上部（ヘッダー下）の余白 | 
| ---- |
| <img width="379" src="https://github.com/user-attachments/assets/13c7dec6-e02c-4f82-8209-d4b1596cef6e" /> |

| ヘッダーのドロップダウン | フッター |
| ---- | ---- |
| <img width="379" alt="スクリーンショット 2025-02-10 22 15 39" src="https://github.com/user-attachments/assets/dfe260c6-bc4a-4e09-8b7e-29e859aec64e" />  | <img width="379" alt="スクリーンショット 2025-02-10 22 15 49" src="https://github.com/user-attachments/assets/a4953b85-a0ef-4e05-9683-0948e1e64251" /> |


**スマートフォンで開いた時の画面上部**
| before | after |
| ---- | ---- |
| ![IMG_4905](https://github.com/user-attachments/assets/ece114c6-dc26-4bfa-93ca-d30d7480d42b) | ![IMG_4904](https://github.com/user-attachments/assets/fd2f9933-713a-4754-a59a-2f5e3b09a266) |
