### PR TITLE
言語別一覧ページのレスポンシブ対応

### DIFF
--- a/app/javascript/controllers/tag_selector.js
+++ b/app/javascript/controllers/tag_selector.js
@@ -20,7 +20,12 @@ function setInitialTagSelection() {
   }
   
   function updateTagSelectStyle(tagSelect, bgColor) {
-    tagSelect.className = `w-1/4 h-12 text-3xl text-white font-bold text-center text-nowrap rounded-lg flex items-center justify-center ${bgColor}`;
+    tagSelect.classList.forEach(cls => {
+      if (cls.startsWith("bg-")) {
+        tagSelect.classList.remove(cls);
+      }
+    });
+    tagSelect.classList.add(bgColor);
   }
   
   function setupTagSelect() {

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -5,32 +5,29 @@
     </h1>
   </div>
 
-<div class="flex flex-col mt-6 m-8">
-  <div class="flex justify-center w-full ">
-    <!-- プルダウンメニュー -->
-    <select id="tag-select" class="custom-select w-1/4 h-12 text-3xl text-white font-bold text-center text-nowrap rounded-lg flex items-center justify-center bg-html">
-      <option value="/tags/1" data-color="bg-html">HTML</option>
-      <option value="/tags/2" data-color="bg-css">CSS</option>
-      <option value="/tags/3" data-color="bg-js">JavaScript</option>
-      <option value="/tags/4" data-color="bg-ruby">Ruby on Rails</option>
-      <option value="/tags/5" data-color="bg-git">Git</option>
-      <option value="/tags/6" data-color="bg-error">エラー</option>
-    </select>
-  </div>
-</div>
-
-  <div id="quiz_content" class="bg-secondary rounded-lg p-6">
-    <div class="rounded-lg p-4">
-      <div class="flex flex-wrap justify-center gap-6">
+  <div class="flex flex-col justify-center">
+    <div class="flex justify-center items-center mb-4 md:mb-6">
+      <!-- プルダウンメニュー -->
+      <select id="tag-select" 
+        class="select w-xs md:w-sm h-12 rounded-lg text-xl md:text-3xl font-bold text-nowrap text-white text-center">
+        <option value="/tags/1" data-color="bg-html">HTML</option>
+        <option value="/tags/2" data-color="bg-css">CSS</option>
+        <option value="/tags/3" data-color="bg-js">JavaScript</option>
+        <option value="/tags/4" data-color="bg-ruby">Ruby on Rails</option>
+        <option value="/tags/5" data-color="bg-git">Git</option>
+        <option value="/tags/6" data-color="bg-error">エラー</option>
+      </select>
+    </div>
+    <div id="quiz_content" class="bg-secondary rounded-lg p-6 m-6 md:m-10">
+      <div class="flex flex-wrap justify-start gap-6">
         <% @quizzes.each do |quiz| %>
           <%= render partial: "quizzes/lg_card", locals: { quiz: quiz } %>
         <% end %>
       </div>
     </div>
-  </div>
-  <!-- ページネーション -->
-  <div class="flex justify-center gap-2">
-    <%= paginate @quizzes %>
+    <!-- ページネーション -->
+    <div class="flex justify-center gap-2">
+      <%= paginate @quizzes %>
+    </div>
   </div>
 </div>
-


### PR DESCRIPTION
## 概要
- 言語別一覧ページのレスポンシブ対応

## 変更内容
- **追加**: 言語別一覧ページのレスポンシブ対応 (`app/views/tags/show.html.erb`)
- **変更**: Tailwindのクラスを削除し、背景色のみを切り替えるよう変更 (`app/javascript/controllers/tag_selector.js`)

## 動作確認方法
1. **言語別一覧ページ**
   - [ ] レスポンシブ対応がされている
   - [ ] これまで通りセレクトボックスでカテゴリの切り替えができる

## 関連Issue
- #80 

## スクリーンショット
言語別一覧ページ
| PC | スマホ |
| ---- | ---- |
<img width="1510" alt="スクリーンショット 2025-02-11 0 37 24" src="https://github.com/user-attachments/assets/3ccf84c3-8878-4101-81ec-a7f56f02ba1f" /> | ![localhost_3000_tags_1(iPhone SE)](https://github.com/user-attachments/assets/3baecfd1-1b05-4544-8962-5bce1048e125) |
