### PR TITLE
h1タイトルの復活

### DIFF
--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -5,7 +5,9 @@
     </h1>
   </div>
 
-
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  </div>
   <% if @contact.errors.any? %>
     <ul>
       <% @contact.errors.full_messages.each do |error| %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,10 +1,13 @@
 <div class="bg-white min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
     <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <%= t('.title') %>
+      <% content_for(:title, 'パスワード再設定') %>
     </h1>
   </div>
 
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  </div>
   <div class="flex bg-secondary rounded justify-center mx-4 md:mx-12 lg:mx-48 mb-8 md:mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-4 md:mx-12 lg:mx-24 space-y-6">
     <p>下記に登録して頂いたメールアドレスにパスワード再設定のご案内メールをお送りいたします。</p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,9 @@
     </h1>
   </div>
 
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  </div>
   <!-- フォームコンテンツ -->
   <div class="flex bg-secondary rounded justify-center mx-4 md:mx-12 lg:mx-48 mb-8 md:mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-4 md:mx-12 lg:mx-24 space-y-6">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,6 +5,10 @@
     </h1>
   </div>
 
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+  　<h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+　</div>
+
   <div class="flex bg-secondary rounded justify-center mx-4 md:mx-12 lg:mx-48 mb-8 md:mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-4 md:mx-12 lg:mx-24 space-y-6">
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/privacy_policies/index.html.erb
+++ b/app/views/privacy_policies/index.html.erb
@@ -5,6 +5,10 @@
     </h1>
   </div>
 
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  </div>
+
 <div class="container mx-auto pt-3 px-12 py-24">
   <div class="mb-6">
     <h2 class="mb-2 text-lg font-bold text-primary">お客様から取得する情報</h2>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -5,10 +5,10 @@
     </h1>
   </div>
 
-<div class="bg-white">
   <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-    <h1 class="text-3xl font-bold text-accent text-center">ユーザープロフィール編集</h1>
-  </div>
+  　<h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+　</div>
+
 
   <%= form_with(model: @user_profile_form, url: user_profile_path, local: true, data: {turbo: false}, method: :patch, multipart: true)  do |f| %>
       <% if @user.errors.any? %>
@@ -79,4 +79,3 @@
     </div>
   <% end %> 
 </div>
-

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,9 +1,14 @@
 <div class="bg-white min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
     <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-        <% content_for(:title, 'マイページ') %>
+      <% content_for(:title, 'マイページ') %>
     </h1>
   </div>
+
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  </div>
+
 
 <div class="bg-gray-50 h-max m-5 p-10 flex flex-col ">
     <div class="flex flex-col justify-center items-center">

--- a/app/views/terms_of_services/index.html.erb
+++ b/app/views/terms_of_services/index.html.erb
@@ -5,6 +5,10 @@
     </h1>
   </div>
 
+  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  </div>
+
 <div class="container mx-auto pt-3 px-12 py-24">
 <p class="mb-6 ">本規約は、提供する「programing_question」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。</p>
 

--- a/config/locales/profile.ja.yml
+++ b/config/locales/profile.ja.yml
@@ -9,6 +9,12 @@ ja:
         github_link: "GitHubリンク"
         update: "更新する"
         destroy: "退会する"
+
+  profiles:
+    show:
+      title: "マイページ"
+    edit:
+      title: "アカウント情報の更新"
   activemodel:
     errors:
       models:


### PR DESCRIPTION
## 概要
- 各ページのタイトル表示復活
- パスワード再設定ページの動的タイトル復活

## 変更内容
- **修正**: 各ページのタイトル表示復活
　- お問い合わせページ（app/views/contacts/new.html.erb）
　- 新規登録ページ(app/views/devise/registrations/new.html.erb)
　- ログインページ(app/views/devise/sessions/new.html.erb)
　- プライバシーポリシーページ（app/views/privacy_policies/index.html.erb）
　- アカウント情報編集ページ(app/views/profiles/edit.html.erb)
　- マイページ(app/views/profiles/show.html.erb)
　- 利用規約ページ(app/views/terms_of_services/index.html.erb)

- パスワード再設定ページの動的タイトル復活

## 動作確認方法
1. **タイトル表示**
   -各ページでタイトルが表示されることを確認

2.パスワード再設定ページでタブにカーソルを合わせると、`パスワード再設定｜ProgramingQuestion`と表示される

## スクリーンショット
- ログインページのタイトル表示(こんな感じで各ページ表示されます)
![image](https://github.com/user-attachments/assets/42a75da6-7d14-45f4-80b5-798621bae32e)

## 備考
- 新規クイズ作成ページに関しては編集しませんでした（編集中のメンバーが居るため）
