### PR TITLE
fix:クイズ解説ページ クイズ作成時の参考資料URLの仕様変更

### DIFF
--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -74,10 +74,12 @@
           <p class="text-sm">
             <%= @question.explanation %>
           </p>
-          <h2 class="mt-12 text-accent">クイズ作成時の参考資料（URL）</h2>
-          <p class="text-sm link">
-            <%= link_to @question.answer_source.truncate(50), @question.answer_source, target: :_blank, rel: "noopener noreferrer" %>
-          </p>
+          <% if @question.answer_source.present? %>
+            <h2 class="mt-12 text-accent">クイズ作成時の参考資料（URL）</h2>
+            <p class="text-sm link">
+              <%= link_to @question.answer_source.truncate(50), @question.answer_source, target: :_blank, rel: "noopener noreferrer" %>
+            </p>
+          <% end %>
           <div>
             <% if @question.question_image.attached? %>
               <h2 class="mt-12 text-accent">問題画像</h2>

--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -76,7 +76,7 @@
           </p>
           <h2 class="mt-12 text-accent">クイズ作成時の参考資料（URL）</h2>
           <p class="text-sm link">
-            <%= link_to @question.answer_source.truncate(50), @question.answer_source %>
+            <%= link_to @question.answer_source.truncate(50), @question.answer_source, target: :_blank, rel: "noopener noreferrer" %>
           </p>
           <div>
             <% if @question.question_image.attached? %>


### PR DESCRIPTION
## 概要
クイズ解説ページ 参考資料URLの仕様を以下の通りに変更をしました。
- 参考資料URLを`target: :_blank`を用いて別タブで開くことができるように修正
- 参考資料URLがnill時の場合、何も表示されないように修正

## 変更内容
- 参考資料URLを`target: :_blank`を用いて別タブで開くことができるように修正(`app/views/questions/result.html.erb`)
- 参考資料URLがnill時の場合、何も表示されないように修正(`app/views/questions/result.html.erb`)

## 動作確認方法
1. **参考資料URLリンクを別タブで開くことができるか**
  [![Image from Gyazo](https://i.gyazo.com/2ac6f8e555ad1b315dc781fc1d6dd2ac.gif)](https://gyazo.com/2ac6f8e555ad1b315dc781fc1d6dd2ac)

2. **参考資料URLがnill時の場合の表記方法**
![スクリーンショット 2025-02-16 10 50 53](https://github.com/user-attachments/assets/9de99e29-fd59-4c68-b628-8085b4d6c877)
![スクリーンショット 2025-02-16 10 51 06](https://github.com/user-attachments/assets/f9829957-a929-4aac-9a59-8474d632cdd2)

## 関連Issue
#465 
#466

