### PR TITLE
feat:利用規約ページのレスポンシブ対応

### DIFF
--- a/app/views/terms_of_services/index.html.erb
+++ b/app/views/terms_of_services/index.html.erb
@@ -5,17 +5,17 @@
     </h1>
   </div>
 
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  <div class="flex flex-col justify-center items-center mt-12 mb-6 md:mb-8 mx-4 md:mx-44">
+    <h1 class="text-xl md:text-3xl lg:text-4xl font-bold text-accent text-center"><%= t('.title') %></h1>
   </div>
 
 <div class="container mx-auto pt-3 px-12 py-24">
-<p class="mb-6 ">本規約は、提供する「programing_question」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。</p>
+<p class="mb-6 text-sm md:text-base">本規約は、提供する「programing_question」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。</p>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第１条（規約の適用）</h2>
-    <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から以下の情報を取得します。</p>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第１条（規約の適用）</h2>
+    <p class="mb-2 text-xs md:text-sm text-gray-700">当サービスは、お客様から以下の情報を取得します。</p>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>本規約は、本サービスを提供する上で、利用者が本サービスの提供を受けるにあたっての諸条件を定めたものです。</li>
       <li>本サービスの提供に関して、本規約のほか、本サービスの利用に関する個別規約その他のガイドライン等を定めることがあります。この場合、当該個別規約その他のガイドライン等は、本規約の一部として利用者による本サービスの利用に優先して適用されるものとします。</li>
       <li>利用者が本サービスを利用された場合、利用者が本規約に同意したものとみなします。</li>
@@ -24,8 +24,8 @@
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第２条（利用登録）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第２条（利用登録）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>利用者は、本サービスが定める方法により必要事項を登録いただくことで、利用登録を行うことができます。</li>
       <li>利用者は、登録事項について、正確かつ最新の情報を届け出なければなりません。</li>
       <li>登録内容に変更が生じた場合、利用者は、速やかに、変更内容を届け出るものとします。</li>
@@ -34,8 +34,8 @@
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第３条（パスワードの管理）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第３条（パスワードの管理）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>利用者が利用登録を行った場合、パスワードを発行します。</li>
       <li>利用者は、パスワードを厳重に管理し、保管するものとし、これを第三者に貸与、譲渡、売買その他の方法をもって利用させてはならないものとします。パスワードの管理が不十分なことにより、利用者が損害又は不利益を被ったとしても、本サービスは責任を負わないものとします。</li>
       <li>パスワードを紛失又は忘失した場合、又はこれらが第三者に使用されていることが判明した場合、利用者は、直ちにその旨を本サービスに通知するものとします。</li>
@@ -44,101 +44,101 @@
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第4条（コンテンツの利用）</h2>
-    <p class="mb-2 text-sm leading-7 text-gray-700">申込みの対象がデジタルコンテンツの場合、当該デジタルコンテンツの利用に係る契約の成立後、当該デジタルコンテンツは利用可能となります。ダウンロードされたものの紛失、破壊又は損傷は利用者の責任となります。疑義を避けるために付言すると、デジタルコンテンツに係る著作権等の知的財産権が利用者に譲渡されるものではございません。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第4条（コンテンツの利用）</h2>
+    <p class="mb-2 text-xs md:text-sm leading-7 text-gray-700">申込みの対象がデジタルコンテンツの場合、当該デジタルコンテンツの利用に係る契約の成立後、当該デジタルコンテンツは利用可能となります。ダウンロードされたものの紛失、破壊又は損傷は利用者の責任となります。疑義を避けるために付言すると、デジタルコンテンツに係る著作権等の知的財産権が利用者に譲渡されるものではございません。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第5条（知的財産権及びコンテンツ）</h2>
-    <p class="text-sm leading-7 text-gray-700">本サービスを構成する全ての素材に関する著作権を含む知的財産権その他の一切の権利は、本サービス又は当該権利を有する第三者に帰属しています。利用者は、本サービスの全ての素材に関して、一切の権利を取得することはないものとし、権利者の許可なく、素材に関する権利を侵害する一切の行為をしてはならないものとします。本規約に基づく本サービスの利用の許諾は、本サービスに関する当社又は当該権利を有する第三者の権利の使用許諾を意味するものではありません。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第5条（知的財産権及びコンテンツ）</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">本サービスを構成する全ての素材に関する著作権を含む知的財産権その他の一切の権利は、本サービス又は当該権利を有する第三者に帰属しています。利用者は、本サービスの全ての素材に関して、一切の権利を取得することはないものとし、権利者の許可なく、素材に関する権利を侵害する一切の行為をしてはならないものとします。本規約に基づく本サービスの利用の許諾は、本サービスに関する当社又は当該権利を有する第三者の権利の使用許諾を意味するものではありません。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第6条（利用者による投稿）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第6条（利用者による投稿）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>本サービス内における利用者による書き込み、レビュー、コメント等の情報及び利用者が掲載、アップロード又は閲覧可能にした画像、イラストその他のコンテンツ（以下「利用者投稿情報」といいます。）は、本サービスの不特定多数の利用者からアクセス及び閲覧されることを十分に理解の上、本サービスをご利用ください。利用者投稿情報については、これを行った利用者が一切の責任を負うものとします。</li>
       <li>利用者は以下の情報の投稿を行うことはできません。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)真実ではないもの</p>
-      <p class="text-sm leading-7 text-gray-700">(2)わいせつな表現又はヌード等のわいせつ画像を含むもの</p>
-      <p class="text-sm leading-7 text-gray-700">(3)他人の名誉又は信用を傷つけるもの</p>
-      <p class="text-sm leading-7 text-gray-700">(4)第三者のプライバシー権、肖像権、著作権その他の権利を侵害するもの</p>
-      <p class="text-sm leading-7 text-gray-700">(5)コンピュータウィルスを含むもの</p>
-      <p class="text-sm leading-7 text-gray-700">(6)当サービスの認めるウェブサイト以外のウェブサイトへのリンクやURL</p>
-      <p class="text-sm leading-7 text-gray-700">(7)その他当サービスが不適当と判断するもの</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)真実ではないもの</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)わいせつな表現又はヌード等のわいせつ画像を含むもの</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(3)他人の名誉又は信用を傷つけるもの</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(4)第三者のプライバシー権、肖像権、著作権その他の権利を侵害するもの</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(5)コンピュータウィルスを含むもの</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(6)当サービスの認めるウェブサイト以外のウェブサイトへのリンクやURL</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(7)その他当サービスが不適当と判断するもの</p>
       <li>利用者は、本サービスが利用者投稿情報を無償で使用することを許諾するものとします。許諾にあたり、利用者は以下を表明し保証するものとします。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)利用者投稿情報に関する著作権、著作隣接権、肖像権その他一切の権利について、正当な権利者であり、又は、正当な権利者から本サービスに係る利用者投稿情報の利用に必要な一切の許諾を受けていること。</p>
-      <p class="text-sm leading-7 text-gray-700">(2)利用者投稿情報の投稿及び当社による利用が、第三者の著作権、著作隣接権、肖像権その他一切の権利を侵害しないこと。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)利用者投稿情報に関する著作権、著作隣接権、肖像権その他一切の権利について、正当な権利者であり、又は、正当な権利者から本サービスに係る利用者投稿情報の利用に必要な一切の許諾を受けていること。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)利用者投稿情報の投稿及び当社による利用が、第三者の著作権、著作隣接権、肖像権その他一切の権利を侵害しないこと。</p>
       <li>利用者に安全に本サービスを利用いただくことを目的として、利用者投稿情報の内容を監視することができるものとします。</li>
       <li>利用者投稿情報が本規約に違反する場合又は以下の事由に該当する場合、利用者への事前の通知なく利用者投稿情報を削除すること及び利用者の投稿の制限を行うことができるものとします。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)投稿から一定期間以上経過した場合</p>
-      <p class="text-sm leading-7 text-gray-700">(2)本サービスの保守管理上、必要と認められる場合</p>
-      <p class="text-sm leading-7 text-gray-700">(3)利用者投稿情報等の容量が当社の使用機器の所定容量を超過した場合又はその恐れが生じた場合</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)投稿から一定期間以上経過した場合</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)本サービスの保守管理上、必要と認められる場合</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(3)利用者投稿情報等の容量が当社の使用機器の所定容量を超過した場合又はその恐れが生じた場合</p>
       <li>前項による削除及び投稿の制限の理由につき、利用者に対し返答する義務を負うものではなく、削除及び制限につき、利用者に発生した損害又は不利益につき、責任を負いません。利用者投稿情報の削除義務を負うものではありません。</li>
     </ul>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第7条（サービスの内容の変更、追加、停止）</h2>
-    <p class="text-sm leading-7 text-gray-700">利用者に事前の通知をすることなく、本サービスの内容の全部又は一部を変更、追加又は停止する場合があり、利用者はこれをあらかじめ承諾するものとします。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第7条（サービスの内容の変更、追加、停止）</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">利用者に事前の通知をすることなく、本サービスの内容の全部又は一部を変更、追加又は停止する場合があり、利用者はこれをあらかじめ承諾するものとします。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第8条（個人情報）</h2>
-    <p class="text-sm leading-7 text-gray-700">利用者による本サービスの利用によって取得する個人情報を、プライバシーポリシーに従い、適切に取り扱います。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第8条（個人情報）</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">利用者による本サービスの利用によって取得する個人情報を、プライバシーポリシーに従い、適切に取り扱います。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第9条（禁止事項）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第9条（禁止事項）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>利用者は、次の行為を行うことはできません。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)本サービスの運営を妨げ、又はそのおそれのある行為</p>
-      <p class="text-sm leading-7 text-gray-700">(2)他の利用者による本サービスの利用を妨害する行為</p>
-      <p class="text-sm leading-7 text-gray-700">(3)本サービスにかかる著作権その他の権利を侵害する行為</p>
-      <p class="text-sm leading-7 text-gray-700">(4)本サービス、他の利用者又は第三者の権利又は利益（名誉権、プライバシー権及び著作権を含みますが、これらに限られません。）を侵害する行為</p>
-      <p class="text-sm leading-7 text-gray-700">(5)公序良俗その他法令に違反する行為及びこれに違反する恐れのある行為</p>
-      <p class="text-sm leading-7 text-gray-700">(6)本規約に違反する行為</p>
-      <p class="text-sm leading-7 text-gray-700">(7)前各号の他、本サービスの趣旨に鑑みて当サービスが不適切と判断する行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)本サービスの運営を妨げ、又はそのおそれのある行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)他の利用者による本サービスの利用を妨害する行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(3)本サービスにかかる著作権その他の権利を侵害する行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(4)本サービス、他の利用者又は第三者の権利又は利益（名誉権、プライバシー権及び著作権を含みますが、これらに限られません。）を侵害する行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(5)公序良俗その他法令に違反する行為及びこれに違反する恐れのある行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(6)本規約に違反する行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(7)前各号の他、本サービスの趣旨に鑑みて当サービスが不適切と判断する行為</p>
       <li>利用者が前項に定める行為を行ったと当社が判断した場合、利用者に事前に通知することなく、本サービスの全部又は一部の利用停止その他当社が必要かつ適切と判断する措置を講じることができます。本項の措置により利用者に生じる損害又は不利益について、一切の責任を負わないものとします。</li>
     </ul>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第10条（反社会的勢力の排除）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第10条（反社会的勢力の排除）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>利用者は、本サービスに対し、次の事項を確約します。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)自らが、暴力団、暴力団関係企業、総会屋若しくはこれらに準ずる者又はその構成員（以下総称して「反社会的勢力」といいます。）ではないこと。</p>
-      <p class="text-sm leading-7 text-gray-700">(2)自らの役員（業務を執行する社員、取締役、執行役又はこれらに準ずる者をいいます。）が反社会的勢力ではないこと。</p>
-      <p class="text-sm leading-7 text-gray-700">(3)反社会的勢力に自己の名義を利用させ、本契約を締結するものでないこと。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)自らが、暴力団、暴力団関係企業、総会屋若しくはこれらに準ずる者又はその構成員（以下総称して「反社会的勢力」といいます。）ではないこと。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)自らの役員（業務を執行する社員、取締役、執行役又はこれらに準ずる者をいいます。）が反社会的勢力ではないこと。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(3)反社会的勢力に自己の名義を利用させ、本契約を締結するものでないこと。</p>
       <li>自ら又は第三者を利用して、次の行為をしないこと。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)相手方に対する脅迫的な言動又は暴力を用いる行為</p>
-      <p class="text-sm leading-7 text-gray-700">(2)法的な責任を超えた不当な要求行為</p>
-      <p class="text-sm leading-7 text-gray-700">(3)偽計又は威力を用いて相手方の業務を妨害し、又は信用を毀損する行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)相手方に対する脅迫的な言動又は暴力を用いる行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)法的な責任を超えた不当な要求行為</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(3)偽計又は威力を用いて相手方の業務を妨害し、又は信用を毀損する行為</p>
     </ul>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第11条（免責事項）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第11条（免責事項）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>天災地変、戦争、テロ行為、暴動、労働争議、伝染病、法令の制定改廃、政府機関の介入その他不可抗力により、本サービスの全部又は一部の停止、中断、遅延が発生した場合、当社は、利用者に生じた損害又は不利益について一切責任を負いません。</li>
       <li>利用者は、通信回線やコンピュータの障害、システムメンテナンスその他の事由による本サービスの全部又は一部の停止、中断、遅延が起こり得ることを理解しているものとし、当社は、これらにより利用者に生じた損害又は不利益について一切責任を負いません。また、利用者の利用環境によって生じた損害又は不利益について、当社は一切責任を負いません。</li>
       <li>当サービスは、以下の掲げる事項について、明示的にも黙示的にも保証しません。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)本サービスの内容及び本サービスを通じて提供される情報の、有用性、完全性、正確性、最新性、信頼性、特定目的への適合性。</p>
-      <p class="text-sm leading-7 text-gray-700">(2)本サービスで提供される情報が第三者の権利を侵害しないものであること。</p>
-      <p class="text-sm leading-7 text-gray-700">(3)本サービスが将来にわたって存続し続けること。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)本サービスの内容及び本サービスを通じて提供される情報の、有用性、完全性、正確性、最新性、信頼性、特定目的への適合性。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)本サービスで提供される情報が第三者の権利を侵害しないものであること。</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(3)本サービスが将来にわたって存続し続けること。</p>
       <li>当社は、理由の如何を問わず、データ等の全部又は一部が滅失、毀損、又は改ざんされた場合に、これを復元する義務を負わないものとし、当該滅失、毀損、又は改ざんによりお客さま又は第三者に生じた損害等について一切の責任を負わないものとします。</li>
     </ul>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第12条（秘密保持）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第12条（秘密保持）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>利用者は、本サービスの利用にあたり、当アプリの管理者より開示を受け、又は知り得た一切の情報について、第三者に開示又は漏えいしてはならず、本サービスの利用以外の目的に使用してはなりません。</li>
     </ul>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第13条（当社からの通知）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第13条（当社からの通知）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>本サービスから利用者に対して通知を行う場合、利用者が登録した電子メールアドレス宛に電子メールを送信する方法、本サービスに係るウェブサイト上への掲示その他当社が適当と判断する方法により行うものとします。</li>
       <li>本サービスが通知を行う場合において、前項の電子メールアドレス宛に送信した場合、当該電子メールアドレスのメールサーバーに記録された時点で、当社の通知は利用者に到達したものとみなします。</li>
       <li>利用者は、第1項の電子メールアドレスに変更がある場合、速やかに当社に通知するものとします。本項の変更の通知を受けるまでに当社が変更前の電子メールアドレス宛に送信した通知は、その発信の時点で利用者に到達したものとみなします。</li>
@@ -147,41 +147,41 @@
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第14条（第三者との紛争）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第14条（第三者との紛争）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>本サービスに関連して利用者と第三者間で発生した紛争については、利用者は自らの費用と責任で解決するものとし、当社は一切の責任を負わないものとします。</li>
       <li>前項に関し、当アプリ管理者が損害（弁護士費用を含みます。）を被った場合、利用者は当該損害を賠償するものとします。</li>
     </ul>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第15条（権利義務の譲渡禁止）</h2>
-    <p class="text-sm leading-7 text-gray-700">利用者は、本規約に基づく契約上の地位及びこれにより生じる権利義務の全部または一部について、本サービスの書面による事前の承諾なく、第三者に対し、譲渡、移転、担保権の設定その他の処分をすることができません。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第15条（権利義務の譲渡禁止）</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">利用者は、本規約に基づく契約上の地位及びこれにより生じる権利義務の全部または一部について、本サービスの書面による事前の承諾なく、第三者に対し、譲渡、移転、担保権の設定その他の処分をすることができません。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第16条（分離可能性）</h2>
-    <p class="text-sm leading-7 text-gray-700">本規約のいずれかの条項が利用者との本規約に基づく契約に適用される法令に違反し、無効とされる場合、当該条項は、その違反とされる限りにおいて、当該利用者との契約には適用されないものとします。この場合でも、本規約の他の条項の効力には影響しません。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第16条（分離可能性）</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">本規約のいずれかの条項が利用者との本規約に基づく契約に適用される法令に違反し、無効とされる場合、当該条項は、その違反とされる限りにおいて、当該利用者との契約には適用されないものとします。この場合でも、本規約の他の条項の効力には影響しません。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第17条（本規約の変更）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第17条（本規約の変更）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>本サービスは、本規約を変更する必要が生じた場合には、民法第548条の4（定型約款の変更）に基づき、本規約を変更することができます。本規約を変更する場合、当社は、その効力発生日を定め、効力発生日までに、電子メールの送信その他の方法により以下の事項を周知するものとします。</li>
-      <p class="text-sm leading-7 text-gray-700">(1)本規約を変更する旨</p>
-      <p class="text-sm leading-7 text-gray-700">(2)変更後の本規約の内容</p>
-      <p class="text-sm leading-7 text-gray-700">(3)効力発生日</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(1)本規約を変更する旨</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(2)変更後の本規約の内容</p>
+      <p class="text-xs md:text-sm leading-7 text-gray-700">(3)効力発生日</p>
     </ul>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第18条（準拠法、裁判管轄）</h2>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第18条（準拠法、裁判管轄）</h2>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>本規約は、日本法に準拠して解釈されます。</li>
     </ul>
   </div>
 
   <div class="flex justify-end">
-    <p class="text-sm text-gray-700"><%= t('.date_of_enactment') %></p>
+    <p class="text-xs md:text-sm text-gray-700"><%= t('.date_of_enactment') %></p>
   </div>
 </div>


### PR DESCRIPTION
## 概要
利用規約ページのレスポンシブ対応を行いました。

## 変更内容
- **新規追加**: 利用規約ページのレスポンシブ対応 (`app/views/terms_of_services/index.html.erb`)

## 動作確認方法
1. **利用規約ページ**
   - [X] `http://localhost:3000/terms_of_services`を閲覧し、レスポンシブ対応が正常に行われているか確認。

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
-  #99

## スクリーンショット（任意）
![スクリーンショット 2025-02-20 9 44 29](https://github.com/user-attachments/assets/491716f8-4398-4cfa-903b-1e55a51754aa)
