### PR TITLE
feat:プライバシーポリシーのレスポンシブ対応

### DIFF
--- a/app/views/privacy_policies/index.html.erb
+++ b/app/views/privacy_policies/index.html.erb
@@ -5,15 +5,15 @@
     </h1>
   </div>
 
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+  <div class="flex flex-col justify-center items-center mt-12 mb-6 md:mb-8 mx-4 md:mx-44">
+    <h1 class="text-xl md:text-3xl lg:text-4xl font-bold text-accent text-center"><%= t('.title') %></h1>
   </div>
 
 <div class="container mx-auto pt-3 px-12 py-24">
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">お客様から取得する情報</h2>
-    <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から以下の情報を取得します。</p>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">お客様から取得する情報</h2>
+    <p class="mb-2 text-xs md:text-sm text-gray-700">当サービスは、お客様から以下の情報を取得します。</p>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>氏名(ニックネームやペンネームも含む)</li>
       <li>メールアドレス</li>
       <li>写真</li>
@@ -25,9 +25,9 @@
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">お客様の情報を利用する目的</h2>
-    <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から取得した情報を、以下の目的のために利用します。</p>
-    <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">お客様の情報を利用する目的</h2>
+    <p class="mb-2 text-xs md:text-sm text-gray-700">当サービスは、お客様から取得した情報を、以下の目的のために利用します。</p>
+    <ul class="pl-8 list-disc text-xs md:text-sm leading-8 text-gray-700">
       <li>当サービスに関する登録の受付、お客様の本人確認、認証のため</li>
       <li>お客様の当サービスの利用履歴を管理するため</li>
       <li>当サービスにおけるお客様の行動履歴を分析し、当サービスの維持改善に役立てるため</li>
@@ -40,29 +40,29 @@
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">安全管理のために講じた措置</h2>
-    <p class="mb-2 text-sm leading-7 text-gray-700">当サービスが、お客様から取得した情報に関して安全管理のために講じた措置につきましては、お問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">安全管理のために講じた措置</h2>
+    <p class="mb-2 text-xs md:text-sm leading-7 text-gray-700">当サービスが、お客様から取得した情報に関して安全管理のために講じた措置につきましては、お問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">第三者提供</h2>
-    <p class="text-sm leading-7 text-gray-700">当サービスは、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">第三者提供</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">当サービスは、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
   </div>
 
   <div class="mb-6">
-    <h2 class="mb-2 text-lg font-bold text-primary">アクセス解析ツール</h2>
-    <p class="text-sm leading-7 text-gray-700">当サービスは、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。</p>
-    <p class="text-sm leading-7 text-gray-700">Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。</p>
-    <p class="mb-2 text-sm leading-7 text-gray-700">Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
-    <%= link_to "Googleアナリティクス利用規約（外部サイト）", "https://marketingplatform.google.com/about/analytics/terms/jp/", target: "_blank", class: "link link-primary text-sm" %>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">アクセス解析ツール</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">当サービスは、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。</p>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。</p>
+    <p class="mb-2 text-xs md:text-sm leading-7 text-gray-700">Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
+    <%= link_to "Googleアナリティクス利用規約（外部サイト）", "https://marketingplatform.google.com/about/analytics/terms/jp/", target: "_blank", class: "link link-primary text-xs md:text-sm" %>
   </div>
 
   <div class="mb-8">
-    <h2 class="mb-2 text-lg font-bold text-primary">プライバシーポリシーの変更</h2>
-    <p class="text-sm leading-7 text-gray-700">当サービスは、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+    <h2 class="mb-2 text-base md:text-lg font-bold text-primary">プライバシーポリシーの変更</h2>
+    <p class="text-xs md:text-sm leading-7 text-gray-700">当サービスは、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
   </div>
 
   <div class="flex justify-end">
-    <p class="text-sm text-gray-700"><%= t('.date_of_enactment') %></p>
+    <p class="text-xs md:text-sm text-gray-700"><%= t('.date_of_enactment') %></p>
   </div>
 </div>


### PR DESCRIPTION
## 概要
プライバシーポリシーページのレスポンシブ対応を行いました。

## 変更内容
- **新規追加**: プライバシーポリシーページのレスポンシブ対応 (`app/views/privacy_policies/index.html.erb`)

## 動作確認方法
1. **お問い合わせページ**
   - [X] `http://localhost:3000/privacy_policies`を閲覧し、レスポンシブ対応が正常に行われているか確認。

## 関連Issue
- #100  

## スクリーンショット（任意）
![スクリーンショット 2025-02-20 9 53 44](https://github.com/user-attachments/assets/a8ce73e4-9c4f-4e8c-93fe-f0665dedd72a)
