### PR TITLE
feat:クイズ検索機能（クイズタイトル、作成者、クイズの説明（解説と解釈しました))

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem "meta-tags", require: "meta_tags"
 
 gem "aws-sdk-s3"
 
+gem "ransack"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.8.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -430,6 +434,7 @@ DEPENDENCIES
   pry
   puma (>= 5.0)
   rails (~> 7.2.2)
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,9 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   before_action :set_user
   before_action :set_profile
+  before_action :set_search
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-
 
 
 
@@ -22,6 +22,10 @@ class ApplicationController < ActionController::Base
 
   def set_profile
     @profile = current_user&.profile if user_signed_in?
+  end
+
+  def set_search
+    @q = Quiz.ransack(params[:q])
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
   before_action :set_user
   before_action :set_profile
   before_action :set_search

--- a/app/controllers/quiz_posts_controller.rb
+++ b/app/controllers/quiz_posts_controller.rb
@@ -2,13 +2,11 @@ class QuizPostsController < ApplicationController
   # 設定したprepare_meta_tagsをprivateにあってもpostコントローラー以外にも使えるようにする
   helper_method :prepare_meta_tags
   before_action :authenticate_user!
-  skip_before_action :authenticate_user!, only: [ :index ]
+  skip_before_action :authenticate_user!, only: [ :index, :search ]
 
   def index
     @quizzes = Quiz.eager_load(:user, :tags).all
-    @tags = Tag.all
-    @newest_quizzes = Quiz.includes(:tags).order(created_at: :desc).first(6)
-    @current_user = current_user
+    set_common_variables
   end
 
   def show
@@ -101,8 +99,19 @@ class QuizPostsController < ApplicationController
     end
   end
 
+  def search
+    @quizzes = @q.result(distinct: true).eager_load(:user, :tags)
+    set_common_variables
+    render :index
+  end
 
   private
+
+  def set_common_variables
+    @tags = Tag.all
+    @newest_quizzes = Quiz.includes(:tags).order(created_at: :desc).first(6)
+    @current_user = current_user
+  end
 
   # show画面の内容がシェアできれば良いので、設定をコントローラーで行う。
   def prepare_meta_tags(quiz)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -19,7 +19,7 @@ class Question < ApplicationRecord
   validates :choices, presence: true, if: -> { question.present? }
 
   def self.ransackable_attributes(auth_object = nil)
-    ["explanation"]
+    [ "explanation" ]
   end
 
   def required_question?

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -18,7 +18,9 @@ class Question < ApplicationRecord
   validates :correct_answer, presence: true, if: -> { question.present? }
   validates :choices, presence: true, if: -> { question.present? }
 
-
+  def self.ransackable_attributes(auth_object = nil)
+    ["explanation"]
+  end
 
   def required_question?
     quiz&.questions&.first == self

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -19,10 +19,10 @@ class Quiz < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    ["questions", "tags", "user"]
+    [ "questions", "tags", "user" ]
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["author_user_id", "created_at", "id", "id_value", "questions_count", "title", "updated_at"]
+    [ "author_user_id", "created_at", "id", "id_value", "questions_count", "title", "updated_at" ]
   end
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -17,4 +17,12 @@ class Quiz < ApplicationRecord
       errors.add(:questions, "は1問から登録できます")
     end
   end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["questions", "tags", "user"]
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["author_user_id", "created_at", "id", "id_value", "questions_count", "title", "updated_at"]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,10 @@ class User < ApplicationRecord
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :uid, uniqueness: { scope: :provider }, allow_nil: true
 
+  def self.ransackable_attributes(auth_object = nil)
+    ["name"]
+  end
+
   # OAuthログイン用メソッド
   def self.from_omniauth(auth)
     user = where(email: auth.info.email).first_or_initialize

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   validates :uid, uniqueness: { scope: :provider }, allow_nil: true
 
   def self.ransackable_attributes(auth_object = nil)
-    ["name"]
+    [ "name" ]
   end
 
   # OAuthログイン用メソッド

--- a/app/views/quiz_posts/index.html.erb
+++ b/app/views/quiz_posts/index.html.erb
@@ -5,48 +5,74 @@
     </h1>
   </div>
 
-<h1 class="text-primary text-center sm:text-xl md:text-2xl bg-secondary p-6 mt-6">プログラミングで人生の可能性を広げよう！</h1>
+  <h1 class="text-primary text-center sm:text-xl md:text-2xl bg-secondary p-6 mt-6">プログラミングで人生の可能性を広げよう！</h1>
 
- <div class="flex flex-col md:flex-row gap-6 p-6 mt-6">
+  <div class="flex flex-col md:flex-row gap-6 p-6 mt-6">
     <!-- Left Column -->
     <div class="w-full md:w-2/3 order-2 md:order-1">
       <div class="bg-secondary p-6 rounded shadow">
         <h2 class="text-primary font-bold sm:text-lg md:text-xl mb-4 flex items-center">
           <span class="material-icons leading-none mr-2">lightbulb_outline</span>
-          クイズを解く
+          <% if params[:q].present? %>
+            検索結果: <%= @quizzes.count %>件
+            <% if params[:q][:title_or_user_name_or_questions_explanation_cont].present? %>
+              (<%= params[:q][:title_or_user_name_or_questions_explanation_cont] %>で検索)
+            <% end %>
+          <% else %>
+            クイズを解く
+          <% end %>
         </h2>
-        <h3 class="text-accent md:text-lg mb-4">クイズカテゴリ一覧</h3>
-        <div class="bg-base-100 rounded p-4">
-          <div class="grid grid-cols-2 lg:grid-cols-3 gap-2">
-            <% @tags.each do |tag| %>
-              <%= link_to tag_path(tag.id), class: "btn flex-1 md:text-lg text-white font-bold text-center text-nowrap my-1 #{tag.data_color}" do %>
-                <%= tag.name %>
+
+        <% if params[:q].present? && @quizzes.empty? %>
+          <div class="bg-base-100 rounded p-4 text-center">
+            <p class="text-gray-600">検索結果が見つかりませんでした。</p>
+            <p class="text-gray-600 mt-2">別のキーワードで試してみてください。</p>
+          </div>
+        <% end %>
+
+        <% if params[:q].present? %>
+          <div class="bg-base-100 rounded py-2">
+            <div class="grid grid-cols-1 lg:grid-cols-2 m-4 gap-4">
+              <% @quizzes.each do |quiz| %>
+                <%= render partial: "quiz_posts/quiz_card", locals: {quiz: quiz} %>
               <% end %>
-            <% end %>
+            </div>
           </div>
-        </div>
+        <% end %>
 
-
-     <div class="text-accent md:text-lg mt-4 mb-4">新着クイズ</div>
-        <div class="bg-base-100 rounded py-2">
-          <div class="grid grid-cols-1 lg:grid-cols-2 m-4 gap-4">
-            <% @newest_quizzes.each do |quiz| %>
-              <%= render partial: "quiz_posts/quiz_card", locals: {quiz: quiz} %>
-            <% end %>
+        <% if !params[:q].present? %>
+          <h3 class="text-accent md:text-lg mb-4">クイズカテゴリ一覧</h3>
+          <div class="bg-base-100 rounded p-4">
+            <div class="grid grid-cols-2 lg:grid-cols-3 gap-2">
+              <% @tags.each do |tag| %>
+                <%= link_to tag_path(tag.id), class: "btn flex-1 md:text-lg text-white font-bold text-center text-nowrap my-1 #{tag.data_color}" do %>
+                  <%= tag.name %>
+                <% end %>
+              <% end %>
+            </div>
           </div>
-        </div>
+
+          <div class="text-accent md:text-lg mt-4 mb-4">新着クイズ</div>
+          <div class="bg-base-100 rounded py-2">
+            <div class="grid grid-cols-1 lg:grid-cols-2 m-4 gap-4">
+              <% @newest_quizzes.each do |quiz| %>
+                <%= render partial: "quiz_posts/quiz_card", locals: {quiz: quiz} %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
-  </div>
 
-  <div class="w-full md:w-1/3 order-1 md:order-2">
-   <%= link_to new_quiz_post_path, class: "block bg-secondary p-4 rounded shadow" do %>
-      <h2 class="text-primary sm:text-lg md:text-xl text-center font-bold p-4 flex items-center justify-center">
+    <div class="w-full md:w-1/3 order-1 md:order-2">
+      <%= link_to new_quiz_post_path, class: "block bg-secondary p-4 rounded shadow" do %>
+        <h2 class="text-primary sm:text-lg md:text-xl text-center font-bold p-4 flex items-center justify-center">
         <span class="material-icons mr-2">
           add_circle_outline
         </span>
-        クイズを作る
-      </h2>
-    <% end %>
+          クイズを作る
+        </h2>
+      <% end %>
 
    <!-- （本リリース）ランキング機能
 <div class="bg-secondary p-6 rounded shadow mt-12">
@@ -104,10 +130,13 @@
   </div>
 </div>
 -->
-  <div class="mt-4 flex justify-center hidden md:block">
-    <%= image_tag "duck_body.png", class: 'mt-4 w-72 h-72 md:w-full h-auto' %>
+      <div class="mt-4 flex justify-center hidden md:block">
+        <%= image_tag "duck_body.png", class: 'mt-4 w-72 h-72 md:w-full h-auto' %>
+      </div>
+    </div>
+
+    <div class="mt-4 flex justify-center block order-3 md:hidden">
+      <%= image_tag "duck_body.png", class: 'mt-4 w-72 h-72 md:w-full h-auto' %>
+    </div>
   </div>
 </div>
-  <div class="mt-4 flex justify-center block order-3 md:hidden">
-    <%= image_tag "duck_body.png", class: 'mt-4 w-72 h-72 md:w-full h-auto' %>
-  </div>

--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -7,7 +7,6 @@
     <div class="flex flex-col w-full justify-end items-center pr-10 md:pr-20 mt-6 md:mt-0">
       <p class="text-xs md:text-sm text-primary ml-auto text-right"><%= t('.create_limit') %></p>
       <p class="text-xs md:text-sm text-primary ml-auto text-right"><%= t('.create_necessary') %></p>
-      <p class="text-xs md:text-sm text-primary ml-auto text-right"><%= t('.create_edit') %></p>
     </div>
   </div>
 
@@ -23,11 +22,6 @@
     </div>
   <% end %>
   <div class="bg-white">
-    <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-      <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-      <p class="text-sm text-primary ml-auto text-right"><%= t('.create_limit') %></p>
-      <p class="text-sm text-primary ml-auto text-right"><%= t('.create_necessary') %></p>
-    </div>
     <div class="flex bg-secondary rounded justify-center px-3 md:px-12 mx-6 md:mx-44 mb-12">
       <div class="flex flex-col w-full mt-6 mb-10 md:mb-6 mx-4 md:mx-6">
         <div class="space-y-4">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <div class="md:ml-5 mx-auto flex justify-between items-center p-4">
     <div class="flex items-center space-x-2 md:space-x-4">
       <%= image_tag 'logo.png', class: 'w-8 h-8 md:w-10 md:h-10' %>
-        <%= link_to 'Programming Question', '/', class: 'text-primary font-bold text-sm md:text-lg font-frankfurter mr-10 text-nowrap' %>
+        <%= link_to 'Programming Question', '/', class: 'text-primary font-bold text-xs md:text-lg font-frankfurter mr-10 text-nowrap' %>
           <%= search_form_for @q, url: search_quiz_posts_path, class: "flex items-center" do |f| %>
             <label for="q_title_or_user_name_or_questions_explanation_cont" class="sr-only">Search</label>
             <div class="flex items-center gap-4">
@@ -18,7 +18,6 @@
                     placeholder: "検索内容を入力してください" %>
               </div>
               <%= f.submit "検索", class: "btn btn-primary btn-sm hover:opacity-70" %>
-              <p class="text-sm text-gray-600">クイズタイトル、作成者、解説で検索が可能です</p>
             </div>
           <% end %>
     </div>
@@ -28,9 +27,9 @@
         <%= link_to user_profile_path(current_user.id) do %>
           <div class="text-center">
             <% if current_user.profile.present? && current_user.profile.user_icon.attached? %>
-              <%= image_tag current_user.profile.user_icon, class: 'w-10 h-10 rounded-full object-cover border border-primary border-300' %>
+              <%= image_tag current_user.profile.user_icon, class: 'w-10 h-10 rounded-full object-cover border border-primary border-300 ml-1' %>
             <% else %>
-              <%= image_tag 'profile_sample.png', class: 'w-10 h-10 rounded-full object-cover border border-primary border-300' %>
+              <%= image_tag 'profile_sample.png', class: 'w-10 h-10 rounded-full object-cover border border-primary border-300 ml-1' %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,9 +3,8 @@
     <div class="flex items-center space-x-2 md:space-x-4">
       <%= image_tag 'logo.png', class: 'w-8 h-8 md:w-10 md:h-10' %>
         <%= link_to 'Programming Question', '/', class: 'text-primary font-bold text-sm md:text-lg font-frankfurter mr-10 text-nowrap' %>
-          <!--（本リリース）検索機能
-          <form class="flex items-center">
-            <label for="simple-search" class="sr-only">Search</label>
+          <%= search_form_for @q, url: search_quiz_posts_path, class: "flex items-center" do |f| %>
+            <label for="q_title_or_user_name_or_questions_explanation_cont" class="sr-only">Search</label>
             <div class="flex items-center gap-4">
               <div class="relative w-full">
                 <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
@@ -13,16 +12,15 @@
                     search
                   </span>
                 </div>
-                <input type="text" id="simple-search"
-                  class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full ps-10 p-2.5"
-                  placeholder="検索" required />
+                <%= f.search_field :title_or_user_name_or_questions_explanation_cont,
+                    id: "q_title_or_user_name_or_questions_explanation_cont",
+                    class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full ps-10 p-2.5",
+                    placeholder: "検索内容を入力してください" %>
               </div>
-              <button type="submit" class="btn btn-primary btn-sm hover:opacity-70">
-                検索
-              </button>
+              <%= f.submit "検索", class: "btn btn-primary btn-sm hover:opacity-70" %>
+              <p class="text-sm text-gray-600">クイズタイトル、作成者、解説で検索が可能です</p>
             </div>
-          </form>
-          -->
+          <% end %>
     </div>
     
     <% if user_signed_in? %>

--- a/config/locales/search.ja.yml
+++ b/config/locales/search.ja.yml
@@ -1,0 +1,3 @@
+ja:
+  defaults:
+    search _word: 検索ワード

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     collection do
       get :bookmarks
       post :create
-      get 'search'
+      get "search"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     collection do
       get :bookmarks
       post :create
+      get 'search'
     end
   end
 


### PR DESCRIPTION
## 概要
- ransackを用いて検索機能の実装を行いました
- 新規クイズ作成ページにおいて重複した記載があったので修正しました

## 変更内容
- **新規追加**: 

  - 　 ransackGemの導入(検索に必要なため) 
  - 　set_searchメソッドの追加(app/controllers/application_controller.rb)
  - self.ransackable_attributes（属性）の記載と、self.ransackable_associations（関連付け）の記載をransackの検索対象のカラムがあるモデルに記載しました
  -  検索用routeを追加しました

- **修正**: 
  - 同じ記載があったsearchとindexの内容をset_common_variables メソッドにしてテンプレートにしました
  
  
```
@tags = Tag.all
    @newest_quizzes = Quiz.includes(:tags).order(created_at: :desc).first(6)
    @current_user = current_user
```

- **削除**:  
   -  allow_browser versions: :modernの記載を削除（レスポンシブ対応のため）(app/controllers/application_controller.rb)
   -  新規クイズ作成ページで重複した記載を消しました 

## 動作確認方法
1. **検索**
   - [ ] クイズタイトル、作成者、解説の内容で検索をするときちんと絞り込まれる
   - [ ] 例えばRと打つだけでRubyOnRailsの問題が絞り込まれる
## 関連Issue
- #195 

## スクリーンショット
- 検索結果
  - nameと検索
  ![image](https://github.com/user-attachments/assets/7e5e484f-5886-44a3-8413-636b08a9ef3a)

  - nと検索
  
  ![image](https://github.com/user-attachments/assets/9ba94e2a-7e7c-42b3-ad5b-91fb3391d879)


## 参考資料
- [[Rails]ransackを使った検索機能](https://qiita.com/nakachan1994/items/72f0fd1cf8193cca8188)
-[ ransackで"Ransack needs attributes explicitly allowlisted..."のエラー解消法](http://qiita.com/Yamashita-Taiki/items/764be62a8c20485ece54)

## 備考
- レスポンシブデザインとのバッティングがあるので、後ほど使用の相談が必要になるかと思います


