### PR TITLE
feat:マイページのレスポンシブ対応

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,7 +8,7 @@ class ProfilesController < ApplicationController
     if @profile.nil? || @profile.new_record?
       redirect_to edit_user_profile_path(@user), alert: "プロフィールを編集してください。"
     else
-      @quizzes = Quiz.eager_load(:user).where(author_user_id: @user.id).page(params[:page]).per(6)
+      @quizzes = Quiz.eager_load(:user).where(author_user_id: @user.id).page(params[:page]).per(4)
     end
   end
 

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 
-<div class="flex justify-center gap-2 my-10">
+<div class="flex justify-center gap-2 my-3 md:my-10">
   <div class="join mt-6">
     <%= paginator.render do -%>
       <nav class="pagination" role="navigation" aria-label="pager">

--- a/app/views/profiles/_my_quizzes.html.erb
+++ b/app/views/profiles/_my_quizzes.html.erb
@@ -1,11 +1,11 @@
-<div class="flex flex-wrap gap-3 items-center justify-center lg:md:justify-between max-w-[1200px]">
+<div class="flex flex-wrap gap-3 items-center justify-center lg:md:justify-between w-full">
   <% if @quizzes.any? %>
     <div class="w-full">
-      <div class="bg-primary w-fit p-3 text-white text-xl my-5">
+      <div class="bg-primary w-fit p-3 text-white text-base md:text-xl my-2 md:my-5">
         <%= @user.name %>が投稿したクイズ一覧
       </div>
     </div>
-    <div class="grid grid-cols-2 gap-4 w-full">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 w-full">
       <% @quizzes.each do |quiz| %>
         <%= render partial: "quizzes/lg_card", locals: { quiz: quiz } %>
       <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,72 +1,71 @@
+<% content_for(:title, t('.title')) %>
 <div class="bg-white min-h-screen overflow-auto">
-  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <% content_for(:title, 'マイページ') %>
+
+  <div class="flex justify-center items-center mt-12 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <%= t('.title') %>
     </h1>
   </div>
 
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-  </div>
-
-
-<div class="bg-gray-50 h-max m-5 p-10 flex flex-col ">
-    <div class="flex flex-col justify-center items-center">
-        <div class="bg-white w-[300px] p-5">
-            <div class="flex space-x-5">
-                <div class="text-center">
-                    <% if @profile.user_icon.attached? %>
-                        <%= image_tag @profile.user_icon, class: 'w-14 h-14 rounded-full object-cover border border-primary border-300' %>
-                    <% else %>
-                        <%= image_tag 'profile_sample.png', class: 'w-14 h-14 rounded-full object-cover border border-primary border-300' %>
-                    <% end %>
-                </div>
-                <div class="text-accent font-bold">
-                    <p class="text-2xl"><%= @user.name %></p>
-                    <!-- （本リリース）フォロー一覧、フォロワー一覧画面への遷移を実装
-                    <div class="flex text-sm space-x-3">
-                        <p>フォロー</p>
-                        <p>フォロワー</p>
-                    </div>
-                    -->
-                </div>
-            </div>
-
-            <div class="flex items-center justify-center text-[25px] space-x-8 my-5">
-                <%= link_to url_for(@profile[:x_link]), target: "_blank", rel: "noopener noreferrer", class: "fa-brands fa-x-twitter #{'opacity-30 pointer-events-none' if @profile[:x_link].blank?}" do %>
-                <% end %>
-
-                <%= link_to url_for(@profile[:github_link]), target: "_blank", rel: "noopener noreferrer", class: "fa-brands fa-github #{'opacity-30 pointer-events-none' if @profile[:github_link].blank?}" do %>
+  <div class="bg-white">
+    <div class="bg-secondary rounded-lg p-6 m-6 md:m-10">
+      <div class="flex flex-col justify-center items-center">
+        <div class="bg-white w-[300px] p-5 md:mt-4">
+          <div class="flex space-x-5">
+            <div class="text-center">
+                <% if @profile.user_icon.attached? %>
+                    <%= image_tag @profile.user_icon, class: 'w-14 h-14 rounded-full object-cover border border-primary border-300' %>
+                <% else %>
+                    <%= image_tag 'profile_sample.png', class: 'w-14 h-14 rounded-full object-cover border border-primary border-300' %>
                 <% end %>
             </div>
-
-            <div class="bg-gray-50 text-sm mb-5 p-5 text-primary">
-                <p><%= @profile.bio %></p>
-                <!--(本リリース)勉強している言語-分かりやすい文面を付け加える
-                <p class="mt-5"><%= @profile[:studying_languages] %></p>
-                -->
+            <div class="text-accent font-bold">
+              <p class="text-xl md:text-2xl"><%= @user.name %></p>
+              <!-- （本リリース）フォロー一覧、フォロワー一覧画面への遷移を実装
+              <div class="flex text-sm space-x-3">
+                  <p>フォロー</p>
+                  <p>フォロワー</p>
+              </div>
+              -->
             </div>
+          </div>
 
-            <% if @user == current_user %>
-                <div class="bg-gray-50 text-sm flex justify-center p-2 mb-3 text-primary">
-                    <span class="material-icons">edit</span>
-                    <%= link_to("編集", edit_user_profile_path)%>
-                </div>
+          <div class="flex items-center justify-center text-[25px] space-x-8 my-5">
+            <%= link_to url_for(@profile[:x_link]), target: "_blank", rel: "noopener noreferrer", class: "fa-brands fa-x-twitter #{'opacity-30 pointer-events-none' if @profile[:x_link].blank?}" do %>
             <% end %>
 
-            <!--# TODO: （本リリース）バッジ画面への遷移を実装
-            <div class="bg-gray-50 text-sm flex justify-center p-2 text-primary">
-                <span class="material-icons">
-                    workspace_premium
-                </span>
-                <p>バッジ</p>
-            </div>
-            -->
-        </div>
-    </div>
+            <%= link_to url_for(@profile[:github_link]), target: "_blank", rel: "noopener noreferrer", class: "fa-brands fa-github #{'opacity-30 pointer-events-none' if @profile[:github_link].blank?}" do %>
+            <% end %>
+          </div>
 
-    <!-- ユーザーが投稿した一覧を表示する部分 -->
-    <div class="inline-flex flex-col items-center" id="paginate">
-        <%= render 'my_quizzes', quizzes: @quizzes %>
+          <div class="bg-gray-50 text-sm mb-5 p-5 text-primary">
+            <p><%= @profile.bio %></p>
+            <!--(本リリース)勉強している言語-分かりやすい文面を付け加える
+            <p class="mt-5"><%= @profile[:studying_languages] %></p>
+            -->
+          </div>
+
+          <% if @user == current_user %>
+            <div class="bg-gray-50 text-sm flex justify-center p-2 mb-3 text-primary">
+                <span class="material-icons">edit</span>
+                <%= link_to("編集", edit_user_profile_path)%>
+            </div>
+          <% end %>
+
+          <!--# TODO: （本リリース）バッジ画面への遷移を実装
+          <div class="bg-gray-50 text-sm flex justify-center p-2 text-primary">
+            <span class="material-icons">
+                workspace_premium
+            </span>
+            <p>バッジ</p>
+          </div>
+          -->
+        </div>
+        <!-- ユーザーが投稿した一覧を表示する部分 -->
+        <div class="inline-flex flex-col items-center md:w-[1200px] mt-6" id="paginate">
+          <%= render 'my_quizzes', quizzes: @quizzes %>
+        </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/app/views/quizzes/_lg_card.html.erb
+++ b/app/views/quizzes/_lg_card.html.erb
@@ -2,7 +2,7 @@
   <div class="flex flex-col w-full space-y-4">
     <!-- クイズタイトル -->
     <%= link_to quiz_post_path(quiz), class: "flex items-center gap-2" do %>
-      <p class="text-accent text-lg font-bold"><%= quiz.title %></p>
+      <p class="text-accent text-base md:text-lg font-bold"><%= quiz.title %></p>
     <% end %>
 
     <!-- 作成者情報 -->


### PR DESCRIPTION
## 概要
- マイページのレスポンシブ対応

## 変更内容
- **追加**: マイページのレスポンシブ対応 (app/views/profiles/show.html.erb)
- **変更**: マイページ内の投稿したクイズ表示件数を4件に変更

## 動作確認方法
<!-- どのように動作確認を行ったか、具体的な手順を記載 -->
1. **マイページ**
   - [ ] レスポンシブ対応がされている

## 関連Issue
- #87 

## スクリーンショット
マイページ
| PC | スマホ |
| ---- | ---- |
| ![localhost_3000_users_5_profile](https://github.com/user-attachments/assets/946556b6-63a5-4c9b-a5bf-ebf6fa2ed84a) | ![localhost_3000_users_5_profile(iPhone XR)](https://github.com/user-attachments/assets/7cf7d84b-b7fb-41f9-bb78-a8f9c67e8cae) |

## 備考
- スマホで表示した際に投稿したクイズが6件表示されると縦に長いため、4件に変更しました。不都合がございましたら教えていただけますと幸いです。