### PR TITLE
feat:ユーザー情報更新ページのレスポンシブ対応

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,14 +1,10 @@
+<% content_for(:title, t('.title')) %>
 <div class="bg-white min-h-screen overflow-auto">
-  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <% content_for(:title, 'アカウント情報の更新') %>
+  <div class="flex flex-col justify-center items-center mt-12 mb-6 md:mb-8 mx-4 md:mx-44">
+    <h1 class="text-xl md:text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <%= t('.title') %>
     </h1>
   </div>
-
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-  　<h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-　</div>
-
 
   <%= form_with(model: @user_profile_form,
                 url: user_profile_path,
@@ -23,58 +19,61 @@
           <% end %>
         </ul>
       <% end %>
-    <div class="flex bg-secondary rounded justify-center mx-48 mb-12">
-      <div class="flex flex-col w-full mt-6 mb-6 mx-24">
-        <div class="space-y-4">
-          <div class="flex flex-col bg-white rounded p-6">
-            <%= f.label(t("activerecord.attributes.profile.name"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
-            <%= f.text_field(:name, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5")  %>
-          </div>
+    <div class="bg-white">
+      <div class="flex bg-secondary rounded justify-center px-3 md:px-12 mx-6 md:mx-44 mb-12">
+        <div class="flex flex-col w-full mt-6 mb-10 md:mb-6 mx-4 md:mx-6">
+          <div class="space-y-4">
 
-          <div class="flex items-center bg-white rounded p-6 gap-8">
-              <h2 class="block text-lg text-nowrap font-medium text-primary">アバター画像</h2>
-              <%= f.file_field :user_icon, class: "file-input file-input-bordered file-input-primary file-input-sm w-full" %>
-          </div>
+            <div class="flex flex-col bg-white rounded p-6">
+              <%= f.label(t("activerecord.attributes.profile.name"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
+              <%= f.text_field(:name, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5")  %>
+            </div>
 
-          <div class="flex flex-col bg-white rounded p-6">
-            <%= f.label(t("activerecord.attributes.profile.bio"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
-            <%= f.text_field(:bio, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20") %>
-          </div>
+            <div class="flex flex-col md:flex-row justify-start items-start md:items-center bg-white rounded p-6 gap-2 md:gap-8">
+                <h2 class="block text-lg text-nowrap font-medium text-primary">アバター画像</h2>
+                <%= f.file_field :user_icon, class: "file-input file-input-bordered file-input-primary file-input-xs md:file-input-sm w-full" %>
+            </div>
 
-          <!-- (本リリース)勉強している言語-分かりやすい文面を付け加える
-          <div class="flex flex-col bg-white rounded p-6">
-            <%= f.label(t("activerecord.attributes.profile.studying_languages"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
-            <%= f.text_field(:studying_languages, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5") %>
-          </div>
-          -->
+            <div class="flex flex-col bg-white rounded p-6">
+              <%= f.label(:bio, t("activerecord.attributes.profile.bio"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
+              <%= f.text_area(:bio, class: "bg-white border border-gray-300 text-sm w-full rounded-lg focus:ring-primary focus:border-primary block p-2.5 h-20 text-start align-top", style: "white-space: normal; word-wrap: break-word;") %>
+            </div>
 
-          <div class="flex flex-col bg-white rounded p-6">
-            <%= f.label(t("activerecord.attributes.profile.x_link"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
-            <%= f.text_field(:x_link, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5") %>
-          </div>
+            <!-- (本リリース)勉強している言語-分かりやすい文面を付け加える
+            <div class="flex flex-col bg-white rounded p-6">
+              <%= f.label(t("activerecord.attributes.profile.studying_languages"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
+              <%= f.text_field(:studying_languages, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5") %>
+            </div>
+            -->
 
-          <div class="flex flex-col bg-white rounded p-6">
-            <%= f.label(t("activerecord.attributes.profile.github_link"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
-            <%= f.text_field(:github_link, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5") %>
-          </div>
+            <div class="flex flex-col bg-white rounded p-6">
+              <%= f.label(t("activerecord.attributes.profile.x_link"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
+              <%= f.text_field(:x_link, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5") %>
+            </div>
 
-          <!-- 更新ボタン -->
-          <div class="flex justify-center mt-12">
-            <%= f.submit(t("activerecord.attributes.profile.update"), class: "btn btn-lg text-white text-center bg-accent text-3xl font-bold rounded-lg w-3/4 h-20") %>
-          </div>
+            <div class="flex flex-col bg-white rounded p-6">
+              <%= f.label(t("activerecord.attributes.profile.github_link"), class: "block mb-2 text-lg text-nowrap font-medium text-primary") %>
+              <%= f.text_field(:github_link, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5") %>
+            </div>
 
-          <!-- 退会ボタン
-          <div class="flex justify-center mt-4">
-            <%= f.submit(t("activerecord.attributes.profile.destroy"), class: "btn btn-lg text-white text-center bg-primary text-2xl font-bold rounded-lg w-3/4 h-16") %>
-          </div>
+            <!-- 更新ボタン -->
+            <div class="flex justify-center mt-12">
+              <%= f.submit(t("activerecord.attributes.profile.update"), class: "text-white bg-accent hover:opacity-70 font-medium rounded-lg text-lg w-full sm:w-auto px-5 py-2.5 text-center") %>
+            </div>
+
+            <!-- 退会ボタン
+            <div class="flex justify-center mt-4">
+              <%= f.submit(t("activerecord.attributes.profile.destroy"), class: "btn btn-lg text-white text-center bg-primary text-2xl font-bold rounded-lg w-3/4 h-16") %>
+            </div>
 
 
-          <div class="text-right mt-2 w-3/4 mx-auto">
-              <p class="text-sm text-gray-600">
-                  ※退会すると全てのデータが削除されます。
-              </p>
+            <div class="text-right mt-2 w-3/4 mx-auto">
+                <p class="text-sm text-gray-600">
+                    ※退会すると全てのデータが削除されます。
+                </p>
+            </div>
+            -->
           </div>
-          -->
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要
- ユーザー情報更新ページのレスポンシブ対応

## 変更内容
- **追加**: ユーザー情報更新ページのレスポンシブ対応 (app/views/profiles/edit.html.erb)

## 動作確認方法
1. **ユーザー情報更新ページ**
   - [ ] レスポンシブ対応がされている

## 関連Issue
- #88

## スクリーンショット
ユーザー情報更新ページ
| PC | スマホ |
| ---- | ---- |
| ![localhost_3000_users_5_profile_edit](https://github.com/user-attachments/assets/9b705e55-7285-40e6-bc83-f7a876e76fa2) | ![localhost_3000_users_5_profile_edit(iPhone XR)](https://github.com/user-attachments/assets/e5990f72-22ef-49ed-9f41-21814c31dac8) |