### PR TITLE
fix:スマートフォンで表示した際のh1レイアウト崩れを修正

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,13 +1,12 @@
+<% content_for(:title, t('.title')) %>
 <div class="bg-white min-h-screen overflow-auto">
-  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <% content_for(:title, 'パスワード再設定') %>
+
+  <div class="flex justify-center items-center mt-12 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <%= "パスワード再設定" %>
     </h1>
   </div>
 
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-  </div>
   <div class="flex bg-secondary rounded justify-center mx-4 md:mx-12 lg:mx-48 mb-8 md:mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-4 md:mx-12 lg:mx-24 space-y-6">
     <p>下記に登録して頂いたメールアドレスにパスワード再設定のご案内メールをお送りいたします。</p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,13 +1,12 @@
+<% content_for(:title, t('.title')) %>
 <div class="bg-white min-h-screen overflow-auto">
-  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <% content_for(:title, '新規登録') %>
+
+  <div class="flex justify-center items-center mt-12 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <%= t('.title') %>
     </h1>
   </div>
 
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-    <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-  </div>
   <!-- フォームコンテンツ -->
   <div class="flex bg-secondary rounded justify-center mx-4 md:mx-12 lg:mx-48 mb-8 md:mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-4 md:mx-12 lg:mx-24 space-y-6">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,13 +1,11 @@
+<% content_for(:title, t('.title')) %>
 <div class="bg-white min-h-screen overflow-auto">
-  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <% content_for(:title, 'ユーザーログイン') %>
+
+  <div class="flex justify-center items-center mt-12 mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+      <%= t('.title') %>
     </h1>
   </div>
-
-  <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
-  　<h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
-　</div>
 
   <div class="flex bg-secondary rounded justify-center mx-4 md:mx-12 lg:mx-48 mb-8 md:mb-12">
     <div class="flex flex-col w-full mt-6 mb-6 mx-4 md:mx-12 lg:mx-24 space-y-6">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -92,14 +92,14 @@
           </div>
           <ul tabindex="0" class="dropdown-content menu bg-white rounded-box p-2 shadow space-y-2">
             <li>
-              <%= link_to 'ログイン', new_user_session_path, class: "text-primary font-bold text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap" %>
+              <%= link_to 'ログイン', new_user_session_path, class: "text-primary text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap" %>
             </li>
             <li>
-              <%= link_to '新規登録', new_user_registration_path, class: 'text-primary font-bold text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
+              <%= link_to '新規登録', new_user_registration_path, class: 'text-primary text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
             </li>
               <!--(本リリース)パスワードリセット機能
             <li>
-              <%= link_to 'パスワードリセット', new_user_password_path, class: 'text-primary font-bold text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
+              <%= link_to 'パスワードリセット', new_user_password_path, class: 'text-primary text-base tracking-wide hover:opacity-70 transition duration-300 text-nowrap' %>
             </li>
               -->
           </ul>


### PR DESCRIPTION
## 概要
- スマートフォンで表示した際のh1レイアウト崩れを修正

## 変更内容
- **修正**: スマートフォンで表示した際のh1レイアウト崩れを修正 (`app/views/devise/sessions/new.html.erb`)
- **修正**: スマートフォンで表示した際のh1レイアウト崩れを修正 (`app/views/devise/registrations/new.html.erb`)
- **修正**: スマートフォンで表示した際のh1レイアウト崩れを修正 (`app/views/devise/passwords/new.html.erb`) ※バックチーム実装前

## 動作確認方法
1. **ログイン／新規登録／パスワード再設定**
   - [ ] スマートフォンで表示した際のh1レイアウト崩れが解消されている

## 関連Issue

## スクリーンショット
**before**
| ログイン | 新規登録 |
| ---- | ---- |
| ![localhost_3000_users_sign_in(iPhone XR)](https://github.com/user-attachments/assets/2578de0e-6f91-4ffa-9733-6e67696f0d18) | ![localhost_3000_users_sign_up(iPhone XR)](https://github.com/user-attachments/assets/0147fa8d-285f-46ad-abd0-a145b17df6cb) |

**after**
| ログイン | 新規登録 | パスワード再設定 |
| ---- | ---- | ---- |
| ![localhost_3000_users_sign_in(iPhone XR) (1)](https://github.com/user-attachments/assets/d091979a-59a9-45c8-b4ce-9af84f3dd2a5) | ![localhost_3000_users_sign_up(iPhone XR) (1)](https://github.com/user-attachments/assets/e8ac32a2-b67b-4461-97b9-448f0a12bd62) | ![localhost_3000_users_password_new(iPhone XR)](https://github.com/user-attachments/assets/d615697b-7bbf-432c-9615-16c7cc1e7305) |