### PR TITLE
fix:Goggleログインの遷移ボタンのUI修正

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -53,33 +53,8 @@
         </div>
       <% end %>
 
-    <!-- MVPリリースでは表示させないため、コメントアウト
-    <div class="divider">または</div>
-
-    <div class="mt-8 md:mt-12 flex justify-center">
-      <button class="gsi-material-button" style="width:255px">
-        <div class="gsi-material-button-state"></div>
-        <div class="gsi-material-button-content-wrapper">
-          <div class="gsi-material-button-icon">
-            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" xmlns:xlink="http://www.w3.org/1999/xlink" style="display: block;">
-              <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
-              <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
-              <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
-              <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
-              <path fill="none" d="M0 0h48v48H0z"></path>
-            </svg>
-          </div>
-          <span class="gsi-material-button-contents">Sign in with Google</span>
-          <span style="display: none;">Sign in with Google</span>
-        </div>
-      </button>
-    </div>
-    -->
-
-
       <div class="flex flex-col items-center space-y-2 text-sm md:text-lg">
         <%= render "devise/shared/links" %>
-        
       </div>
     </div>
   </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,10 +20,21 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Googleでログイン", 
-                  omniauth_authorize_path(resource_name, provider), 
-                  data: { turbo: false }, 
-                  class: "google-login-button" %><br />
+
+  <div class="divider ">または</div>
+    <%= button_to omniauth_authorize_path(resource_name, provider),
+                  data: { turbo: false },
+                  class: "mt-4 flex justify-center items-center bg-white hover:opacity-70 font-medium rounded-lg text-lg w-64 px-5 py-3 text-center" do %>
+      <div class="gsi-material-button-icon mr-2">
+        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" xmlns:xlink="http://www.w3.org/1999/xlink" class="w-6 h-6">
+          <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+          <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+          <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+          <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+          <path fill="none" d="M0 0h48v48H0z"></path>
+        </svg>
+      </div>
+      <span class="gsi-material-button-contents">Googleでログイン</span>
+    <% end %>
   <% end %>
 <% end %>
-


### PR DESCRIPTION
## 概要
ログインページ・新規登録ページ・パスワード再設定ページのGoggleログインの遷移ボタンのUI修正を行いました。

## 変更内容
- Goggleログインの遷移ボタンのUI修正(`app/views/devise/shared/_links.html.erb`)
-  Goggleログインの遷移ボタンに関する不要なコードを削除(`app/views/devise/sessions/new.html.erb`)

## 動作確認方法
1. **ログインページ・新規登録ページ・パスワード再設定ページ**
   - [X] 各ページのローカル環境でGoggleログインの遷移ボタンのUIが意図通り表示されているか確認。

## 関連Issue
- #506

## スクリーンショット（任意）
| ログインページ | 新規登録ページ | パスワード再設定ページ |
| ---- | ---- | ---- |
| ![スクリーンショット 2025-02-21 12 32 36](https://github.com/user-attachments/assets/53aee6d1-a00b-4f55-a004-b119bc6dcce7)| ![スクリーンショット 2025-02-21 12 32 56](https://github.com/user-attachments/assets/b5f67ee5-6260-4dd4-91e7-02e77eb4908f) | ![スクリーンショット 2025-02-21 12 33 08](https://github.com/user-attachments/assets/487dd1f6-f15a-4dae-add6-dcb2a1d234f0)|