### PR TITLE
Fix question input overflow

### DIFF
--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -69,7 +69,9 @@
                     <%= q_form.label :question, t('.question'), class: "block mb-2 text-base md:text-lg text-nowrap font-medium text-primary" %>
                     <span class="text-accent ml-1">*</span>
                   </div>
-                  <%= q_form.rich_text_area :question, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5 h-20" %>
+                  <div>
+                    <%= q_form.rich_text_area :question, class: "bg-white border border-gray-300 text-sm w-full rounded-lg forcus:ring-primary focus:border-primary block p-2.5" %>
+                  </div>
                 </div>
                 <div class="bg-white rounded">
                   <div class="flex flex-col md:flex-row justify-between md:space-x-4 p-2 md:p-6 w-full">

--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -59,7 +59,7 @@
             </div>
           </div>
           <div class="divider"></div>
-          <%= form.fields_for :questions, @current_question do |q_form| %>         
+          <%= form.fields_for :questions, @current_question do |q_form| %>
             <div class="collapse collapse-arrow bg-white">
               <input type="checkbox" />
               <div class="collapse-title text-base md:text-lg font-medium text-primary"><%= t('.accordion_title') %></div>


### PR DESCRIPTION
## 概要
問題入力フォームからの文字のはみ出しを修正しました。

## 変更内容
<!-- 具体的な変更内容や追加した機能について箇条書きで記載 -->
- **修正**: 問題入力フォームからの文字のはみ出しの修正

## 動作確認方法
<!-- どのように動作確認を行ったか、具体的な手順を記載 -->
1. **長文入力**
   - [ ] 長い問題文を入力してもフォームから文字がはみ出さない

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->

## スクリーンショット（任意）
<!-- UI の変更がある場合は、変更箇所のスクリーンショットを添付 -->
- 従来
  <img width="898" alt="スクリーンショット 2025-02-24 21 10 52" src="https://github.com/user-attachments/assets/d652b523-85ac-4097-b6da-2d779f522d1b" />
- 修正後
  <a href="https://gyazo.com/f99fbcf7dc9f8d2187e42679fbbe0785"><img src="https://i.gyazo.com/f99fbcf7dc9f8d2187e42679fbbe0785.gif" alt="Image from Gyazo" width="916"/></a>

## 参考資料
<!-- 参考にした資料やURLがあれば記載 -->

## 備考
<!-- その他、レビュアーに伝えたいことがあれば記載 -->
- ActionText導入プルリクをマージ直後、下記エラーが発生しました。
  ```
  web-1  | 20:37:31 js.1   | ✘ [ERROR] Could not resolve "trix"
  web-1  | 20:37:31 js.1   | 
  web-1  | 20:37:31 js.1   |     app/javascript/application.js:6:7:
  web-1  | 20:37:31 js.1   |       6 │ import "trix"
  web-1  | 20:37:31 js.1   |         ╵        ~~~~~~
  web-1  | 20:37:31 js.1   | 
  web-1  | 20:37:31 js.1   |   You can mark the path "trix" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle.
  web-1  | 20:37:31 js.1   | 
  web-1  | 20:37:31 js.1   | ✘ [ERROR] Could not resolve "@rails/actiontext"
  web-1  | 20:37:31 js.1   | 
  web-1  | 20:37:31 js.1   |     app/javascript/application.js:7:7:
  web-1  | 20:37:31 js.1   |       7 │ import "@rails/actiontext"
  web-1  | 20:37:31 js.1   |         ╵        ~~~~~~~~~~~~~~~~~~~
  web-1  | 20:37:31 js.1   | 
  web-1  | 20:37:31 js.1   |   You can mark the path "@rails/actiontext" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle.
  ```
  `rails action_text:install`を実行し、差分を全て捨てたらなぜか解消しました。共有まで。