### PR TITLE
fix:新規作成ページ アコーディオンタイトルの問題インデックス表示の修正

### DIFF
--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -59,10 +59,10 @@
             </div>
           </div>
           <div class="divider"></div>
-          <%= form.fields_for :questions, @current_question do |q_form| %>         
+          <%= form.fields_for :questions, @current_question do |q_form| %>
             <div class="collapse collapse-arrow bg-white">
               <input type="checkbox" />
-              <div class="collapse-title text-base md:text-lg font-medium text-primary"><%= t('.accordion_title') %></div>
+              <div class="collapse-title text-base md:text-lg font-medium text-primary"><%= t(".accordion_title", index: q_form.index + 1) %></div>
               <div class="collapse-content">
                 <div class="flex flex-col bg-white rounded p-2 md:p-6">
                   <div class="flex items-start">

--- a/config/locales/quiz.ja.yml
+++ b/config/locales/quiz.ja.yml
@@ -41,7 +41,7 @@ ja:
       quizes_title: "クイズ集タイトル"
       quizes_tags: "クイズカテゴリを選択"
       tags_annotation: "※ エラータグのみ他タグと組み合わせた選択が可能です。"
-      accordion_title: "問題"
+      accordion_title: "問題 %{index}"
       question: "問題文"
       choices:
         1: "選択肢1"


### PR DESCRIPTION
## 概要
新規作成ページのアコーディオンタイトルにインデックスをふりました。
例）「問題」→「問題1,問題2・・・問題10」

## 変更内容
- **修正**: アコーディオンタイトルのインデックス表示の修正(`app/views/quiz_posts/new.html.erb`)
- **修正**: 上記に関する日本語化の修正(`config/locales/quiz.ja.yml`)


## 動作確認方法
1. **新規作成ページ**
   - [X] `http://localhost:3000/quiz_posts/new`にて、アコーディオンタイトルにインデックスが振られ、正常にクイズが作成できることを確認。また、レスポンシブ対応時も問題のないことを確認。

## 関連Issue
- #515

## スクリーンショット（任意）
![スクリーンショット 2025-02-28 12 58 19](https://github.com/user-attachments/assets/2e151d4f-6883-4b92-868e-804f7bcf4dc1)
