### PR TITLE
Add/loginなしでクイズを解けるようにする

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -60,13 +60,13 @@ end
 
     if user_signed_in?
       @past_answer = PastAnswer.find_by(question_id: @question.id, user_id: current_user.id)
-  
+
       # もし `PastAnswer` が見つからない場合はエラー表示
       unless @past_answer
         flash[:alert] = "回答履歴が見つかりませんでした。"
         redirect_to root_path and return
       end
-  
+
       @is_correct = @past_answer.answer_result
     else
       @is_correct = session[:is_correct]

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,5 +1,5 @@
 class QuestionsController < ApplicationController
-  before_action :authenticate_user!, except: [ :new ] # ログインが必要なアクションを設定
+  before_action :authenticate_user!, except: [ :new, :show, :create_result, :result ] # ログインが必要なアクションを設定
 
   def new
   end
@@ -27,23 +27,28 @@ class QuestionsController < ApplicationController
   user_answer = params[:answer]
   correct_answer = @question.correct_answer
   is_correct = (user_answer.to_s == correct_answer.to_s)
-  redirect_to result_question_path(question_id: @question.id, is_correct: is_correct)
 
-  past_answer = PastAnswer.find_or_initialize_by(
-    question_id: @question.id,
-    user_id: current_user.id
-  )
+  session[:is_correct] = is_correct
 
-  if past_answer.update(
-    answer_content: user_answer,
-    answer_result: is_correct
-  )
-    Rails.logger.info("PastAnswer saved successfully: #{past_answer.inspect}")
-  else
-    Rails.logger.error("Failed to save PastAnswer: #{past_answer.errors.full_messages.join(', ')}")
-    flash[:alert] = "回答の保存に失敗しました。"
-    redirect_to root_path and return
+  if user_signed_in?
+    past_answer = PastAnswer.find_or_initialize_by(
+      question_id: @question.id,
+      user_id: current_user.id
+    )
+
+    if past_answer.update(
+      answer_content: user_answer,
+      answer_result: is_correct
+    )
+      Rails.logger.info("PastAnswer saved successfully: #{past_answer.inspect}")
+    else
+      Rails.logger.error("Failed to save PastAnswer: #{past_answer.errors.full_messages.join(', ')}")
+      flash[:alert] = "回答の保存に失敗しました。"
+      redirect_to root_path and return
+    end
   end
+
+  redirect_to result_question_path(question_id: @question.id, is_correct: is_correct)
 end
 
 
@@ -53,10 +58,19 @@ end
     @choices = Choice.where(question_id: @question.id)
     @quiz = @question.quiz
 
-    @past_answer = PastAnswer.find_by(question_id: @question.id, user_id: current_user.id)
-    unless @past_answer
-      flash[:alert] = "回答履歴が見つかりませんでした。"
-      redirect_to root_path and return
+    if user_signed_in?
+      @past_answer = PastAnswer.find_by(question_id: @question.id, user_id: current_user.id)
+  
+      # もし `PastAnswer` が見つからない場合はエラー表示
+      unless @past_answer
+        flash[:alert] = "回答履歴が見つかりませんでした。"
+        redirect_to root_path and return
+      end
+  
+      @is_correct = @past_answer.answer_result
+    else
+      @is_correct = session[:is_correct]
+      session.delete(:is_correct)  # 正誤情報をクリア
     end
 
     @next_question = Question.where("id > ? AND quiz_id = ?", @question.id, @quiz.id).order(:id).first

--- a/app/controllers/quiz_posts_controller.rb
+++ b/app/controllers/quiz_posts_controller.rb
@@ -2,7 +2,7 @@ class QuizPostsController < ApplicationController
   # 設定したprepare_meta_tagsをprivateにあってもpostコントローラー以外にも使えるようにする
   helper_method :prepare_meta_tags
   before_action :authenticate_user!
-  skip_before_action :authenticate_user!, only: [ :index, :search, :autocomplete ]
+  skip_before_action :authenticate_user!, only: [ :index, :search, :autocomplete, :show ]
 
   def index
     @quizzes = Quiz.eager_load(:user, :tags).all

--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -19,9 +19,9 @@
       </div>
 
       <div class="flex gap-8 justify-center items-center mt-12">
-        <%= image_tag @past_answer.answer_result ? 'duck_correct.png' : 'duck_incorrect.png', class: 'w-16 h-16' %>
+        <%= image_tag @is_correct ? 'duck_correct.png' : 'duck_incorrect.png', class: 'w-16 h-16' %>
           <p class="text-2xl">
-            <% if @past_answer.answer_result %>
+            <% if @is_correct %>
               <i class="fa-regular fa-circle text-md text-red-500"></i> 正解
             <% else %>
               <i class="fa-solid fa-x text-md text-blue-500"></i> 不正解

--- a/app/views/quiz_posts/show.html.erb
+++ b/app/views/quiz_posts/show.html.erb
@@ -11,14 +11,14 @@
       <div class="flex justify-between items-center">
         <h1 class="text-lg md:text-3xl text-accent"><%= @quiz.title %></h1>
         <div class="flex text-primary">
-          <% if @quiz.author_user_id == current_user.id || current_user.admin? %>
+          <% if user_signed_in? && (@quiz.author_user_id == current_user.id || current_user.admin?) %>
             <!-- クイズ編集ボタン -->
             <%= link_to edit_quiz_post_path(@quiz), class: "text-primary" do %>
               <span class="material-icons md-36">edit</span>
             <% end %>
           <% end %>
           <div class="flex text-primary space-x-4">
-            <% if @quiz.author_user_id == current_user.id || current_user.admin? %>
+            <% if user_signed_in? && (@quiz.author_user_id == current_user.id || current_user.admin?) %>
               <%= button_to @quiz,
               method: :delete do %>
                 <span class="material-icons md-36" >


### PR DESCRIPTION
## 概要
<!-- このプルリクエストで何を実装・修正したのか具体的に記載してください -->
- 未ログイン時でもクイズを解けるようにしました

## 変更内容
<!-- 具体的な変更内容や追加した機能について箇条書きで記載 -->
- **修正**: quiz_post_showページとクイズ回答ページをログインなしで表示できるようにしました。(`app/controllers/quiz_posts_controller.rb`)(`app/controllers/questions_controller.rb`)
```ruby
skip_before_action :authenticate_user!, only: [ :index, :search, :autocomplete, :show ]
```
```ruby
before_action :authenticate_user!, except: [ :new, :show, :create_result, :result ]
```
- **修正**: ログインしていない場合はresult 画面で正誤を取得できるようにセッションに is_correct を保存`(session[:is_correct] = is_correct)`。
ログインしている場合はこれまで通り PastAnswer を保存する。(`app/controllers/questions_controller.rb`)

- **修正**: 上記に伴いインスタント変数を変更 (`app/views/questions/result.html.erb`)
- **修正**: ログイン状態か確認するコードを追加 (`app/views/quiz_posts/show.html.erb`)

## 動作確認方法
<!-- どのように動作確認を行ったか、具体的な手順を記載 -->
1. **ログイン前**
   - [x] クイズが正しく解ける
2. **ログイン前**
   - [x] 編集、削除ボタンが表示されない
3. **ログイン後**
   - [x] クイズが正しく解ける
2. **ログイン後**
   - [x] 編集、削除ボタンが表示される
## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
- close #451

## スクリーンショット（任意）
<!-- UI の変更がある場合は、変更箇所のスクリーンショットを添付 -->
- ログイン前クイズ回答ページ
![スクリーンショット 2025-03-05 6 40 06](https://github.com/user-attachments/assets/a3ceee25-46f5-4275-8e71-b9f0da03dedc)
![スクリーンショット 2025-03-05 6 29 50](https://github.com/user-attachments/assets/cfcfe2b9-c43c-4f53-8b00-5982f6494150)
![スクリーンショット 2025-03-05 6 30 06](https://github.com/user-attachments/assets/7023a6b3-5698-4f92-ad4f-1cc8dc3020d5)


## 参考資料
<!-- 参考にした資料やURLがあれば記載 -->

## 備考
<!-- その他、レビュアーに伝えたいことがあれば記載 -->
- 今後回答履歴を残すとなどといった場合ゲストユーザーだと過去の他者が解いた回答履歴が残ると思いゲストユーザーは作成しませんでした。