### PR TITLE
Fix クイズ作成エラー時の挙動修正

### DIFF
--- a/app/controllers/quiz_posts_controller.rb
+++ b/app/controllers/quiz_posts_controller.rb
@@ -42,7 +42,7 @@ class QuizPostsController < ApplicationController
         format.html { redirect_to quiz_post_path(@quiz), notice: "クイズを投稿しました！" }
       else
         flash.now[:alert] = "クイズの投稿に失敗しました"
-        format.turbo_stream { render 'turbo_stream/quiz_posts/create_failed', status: :unprocessable_entity }
+        format.turbo_stream { render "turbo_stream/quiz_posts/create_failed", status: :unprocessable_entity }
       end
     end
     Rails.logger.info "Received tag_ids: #{params[:quiz][:tag_ids]}"

--- a/app/controllers/quiz_posts_controller.rb
+++ b/app/controllers/quiz_posts_controller.rb
@@ -41,6 +41,7 @@ class QuizPostsController < ApplicationController
       if @quiz.save
         format.html { redirect_to quiz_post_path(@quiz), notice: "クイズを投稿しました！" }
       else
+        flash.now[:alert] = "クイズの投稿に失敗しました"
         format.turbo_stream { render 'turbo_stream/quiz_posts/create_failed', status: :unprocessable_entity }
       end
     end

--- a/app/controllers/quiz_posts_controller.rb
+++ b/app/controllers/quiz_posts_controller.rb
@@ -37,21 +37,23 @@ class QuizPostsController < ApplicationController
 
     @quiz.questions = @quiz.questions.select { |q| q.question.present? }
 
-    if @quiz.save
-      redirect_to quiz_post_path(@quiz), notice: "クイズを投稿しました！"
-    else
-      if current_user.admin?
-        30.times do
-          question = @quiz.questions.build
-          question.choices.build # 1回だけchoicesを作成
-        end
+    respond_to do |format|
+      if @quiz.save
+        format.html { redirect_to quiz_post_path(@quiz), notice: "クイズを投稿しました！" }
       else
-        10.times do
-          question = @quiz.questions.build
-          question.choices.build # 1回だけchoicesを作成
+        if current_user.admin?
+          30.times do
+            question = @quiz.questions.build
+            question.choices.build # 1回だけchoicesを作成
+          end
+        else
+          10.times do
+            question = @quiz.questions.build
+            question.choices.build # 1回だけchoicesを作成
+          end
         end
+        render :new, status: :unprocessable_entity
       end
-      render :new, status: :unprocessable_entity
     end
     Rails.logger.info "Received tag_ids: #{params[:quiz][:tag_ids]}"
   end

--- a/app/controllers/quiz_posts_controller.rb
+++ b/app/controllers/quiz_posts_controller.rb
@@ -41,18 +41,7 @@ class QuizPostsController < ApplicationController
       if @quiz.save
         format.html { redirect_to quiz_post_path(@quiz), notice: "クイズを投稿しました！" }
       else
-        if current_user.admin?
-          30.times do
-            question = @quiz.questions.build
-            question.choices.build # 1回だけchoicesを作成
-          end
-        else
-          10.times do
-            question = @quiz.questions.build
-            question.choices.build # 1回だけchoicesを作成
-          end
-        end
-        render :new, status: :unprocessable_entity
+        format.turbo_stream { render 'turbo_stream/quiz_posts/create_failed', status: :unprocessable_entity }
       end
     end
     Rails.logger.info "Received tag_ids: #{params[:quiz][:tag_ids]}"

--- a/app/views/devise/shared/_flash_messages.html.erb
+++ b/app/views/devise/shared/_flash_messages.html.erb
@@ -1,9 +1,11 @@
-<% if flash.present? %>
-  <div class="space-y-4">
-    <% flash.each do |key, message| %>
-      <div class="<%= key == 'notice' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %> px-4 py-3 rounded-lg shadow-md">
-        <p class="font-medium"><%= message %></p>
-      </div>
-    <% end %>
-  </div>
+<%= turbo_frame_tag 'flash_messages' do %>
+  <% if flash.present? %>
+    <div class="space-y-4">
+      <% flash.each do |key, message| %>
+        <div class="<%= key == 'notice' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %> px-4 py-3 rounded-lg shadow-md">
+          <p class="font-medium"><%= message %></p>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/quiz_posts/new.html.erb
+++ b/app/views/quiz_posts/new.html.erb
@@ -11,16 +11,7 @@
   </div>
 
   <%= form_with model: @quiz, url: quiz_posts_path, local: true do |form| %>
-    <% if @quiz.errors.any? %>
-      <div class="error-messages bg-red-100 text-red-700 border border-red-400 p-4 rounded mb-4">
-        <h2 class="text-lg font-bold mb-2"><%= t('.errors_blank') %></h2>
-        <ul class="list-disc pl-5">
-          <% @quiz.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+    <%= render 'shared/error_messages', model: @quiz %>
     <div class="bg-white">
       <div class="flex bg-secondary rounded justify-center px-3 md:px-12 mx-6 md:mx-44 mb-12">
         <div class="flex flex-col w-full mt-6 mb-10 md:mb-6 mx-4 md:mx-6">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,10 @@
+<% if model.errors.any? %>
+  <div class="error-messages bg-red-100 text-red-700 border border-red-400 p-4 rounded mb-4">
+    <h2 class="text-lg font-bold mb-2"><%= t('.errors_blank') %></h2>
+    <ul class="list-disc pl-5">
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,10 +1,12 @@
-<% if model.errors.any? %>
-  <div class="error-messages bg-red-100 text-red-700 border border-red-400 p-4 rounded mb-4">
-    <h2 class="text-lg font-bold mb-2"><%= t('.errors_blank') %></h2>
-    <ul class="list-disc pl-5">
-      <% model.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
+<%= turbo_frame_tag 'error_messages' do %>
+  <% if model.errors.any? %>
+    <div class="error-messages bg-red-100 text-red-700 border border-red-400 p-4 rounded mb-4">
+      <h2 class="text-lg font-bold mb-2"><%= t('.errors_blank') %></h2>
+      <ul class="list-disc pl-5">
+        <% model.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/turbo_stream/quiz_posts/create_failed.turbo_stream.erb
+++ b/app/views/turbo_stream/quiz_posts/create_failed.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "error_messages" do %>
+  <%= render partial: "shared/error_messages", locals: { model: @quiz } %>
+<% end %>

--- a/app/views/turbo_stream/quiz_posts/create_failed.turbo_stream.erb
+++ b/app/views/turbo_stream/quiz_posts/create_failed.turbo_stream.erb
@@ -1,3 +1,7 @@
 <%= turbo_stream.update "error_messages" do %>
   <%= render partial: "shared/error_messages", locals: { model: @quiz } %>
 <% end %>
+
+<%= turbo_stream.update "flash_messages" do %>
+  <%= render partial: "devise/shared/flash_messages" %>
+<% end %>


### PR DESCRIPTION
## 概要
クイズ作成エラー時に、選択タグがリセットされてしまう不具合を修正しました。

## 変更内容
- **修正**: `quiz_posts/create`アクション時に、`turbo_stream`で処理を行うように変更
  - 成功時: `format.html`でクイズ詳細画面へリダイレクト
  - 失敗時: `format.turbo_stream`で、フラッシュメッセージとエラーメッセージのパーシャルだけ更新

## 動作確認方法
<!-- どのように動作確認を行ったか、具体的な手順を記載 -->
1. **クイズ作成成功時**
   - [ ] クイズ詳細画面へリダイレクトされる
    [![Image from Gyazo](https://i.gyazo.com/189143f6928d0df30ab1f5367faaadab.gif)](https://gyazo.com/189143f6928d0df30ab1f5367faaadab)
2. **クイズ作成失敗時**
   - [ ] エラーメッセージ・フラッシュメッセージのみ更新される
     [![Image from Gyazo](https://i.gyazo.com/29fdb46f7026ebfc2682c3555faf5bfb.gif)](https://gyazo.com/29fdb46f7026ebfc2682c3555faf5bfb)

## 関連Issue

## スクリーンショット（任意）

## 参考資料

## 備考
<!-- その他、レビュアーに伝えたいことがあれば記載 -->
- 登録エラーの際、「登録する」を押してからページの一番上に戻らないとエラー文を読めないため、UX的に微妙な可能性があります🤥
  [![Image from Gyazo](https://i.gyazo.com/e68921b3fb2e53acaaceae9dbc4e9b53.gif)](https://gyazo.com/e68921b3fb2e53acaaceae9dbc4e9b53)